### PR TITLE
fix(read-only):  timeout polls between queries

### DIFF
--- a/.github/workflows/run-e2e.yaml
+++ b/.github/workflows/run-e2e.yaml
@@ -67,7 +67,7 @@ jobs:
           echo "${{ secrets.E2E_TEST_CONFIG }}" > ./e2e/setup/application.yml
           echo "${{ secrets.E2E_BRIDGE_CONFIG }}" > ./e2e/setup/bridge.yml
       - name: Run E2E Tests
-        run: go test ./e2e/ -timeout 1200s # 20 minutes
+        run: go test ./e2e/ -timeout 1500s # 25 minutes
       - name: Prepare container logs
         if: ${{ always() }}
         run: |

--- a/app/services/read-only/service.go
+++ b/app/services/read-only/service.go
@@ -26,20 +26,24 @@ import (
 	"github.com/limechain/hedera-eth-bridge-validator/config"
 	"github.com/limechain/hedera-eth-bridge-validator/constants"
 	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 type Service struct {
 	mirrorNode         client.MirrorNode
 	transferRepository repository.Transfer
+	pollingInterval    time.Duration
 	logger             *log.Entry
 }
 
 func New(
 	mirrorNode client.MirrorNode,
-	transferRepository repository.Transfer) *Service {
+	transferRepository repository.Transfer,
+	pollingInterval time.Duration) *Service {
 	return &Service{
 		mirrorNode:         mirrorNode,
 		transferRepository: transferRepository,
+		pollingInterval:    pollingInterval,
 		logger:             config.GetLoggerFor("Read-only Transfer Fetcher"),
 	}
 }
@@ -107,6 +111,9 @@ func (s Service) FindAssetTransfer(
 		if finished {
 			break
 		}
+		s.logger.Tracef("[%s] - No asset transfers found.", transferID)
+
+		time.Sleep(s.pollingInterval * time.Second)
 	}
 }
 
@@ -171,6 +178,9 @@ func (s Service) FindTransfer(
 		if finished {
 			break
 		}
+
+		s.logger.Tracef("[%s] - No transfers found.", transferID)
+		time.Sleep(s.pollingInterval * time.Second)
 	}
 }
 

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -104,7 +104,7 @@ func PrepareServices(c config.Config, clients Clients, repositories Repositories
 		scheduled,
 		transfers)
 
-	readOnly := read_only.New(clients.MirrorNode, repositories.transfer)
+	readOnly := read_only.New(clients.MirrorNode, repositories.transfer, c.Node.Clients.MirrorNode.PollingInterval)
 
 	return &Services{
 		signers:          evmSigners,
@@ -115,6 +115,7 @@ func PrepareServices(c config.Config, clients Clients, repositories Repositories
 		lockEvents:       lockEvent,
 		fees:             fees,
 		distributor:      distributor,
+		scheduled:        scheduled,
 		readOnly:         readOnly,
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1452,7 +1452,7 @@ func verifyTopicMessages(setup *setup.Setup, txId string, t *testing.T) []string
 	}
 
 	select {
-	case <-time.After(90 * time.Second):
+	case <-time.After(120 * time.Second):
 		if ethSignaturesCollected != expectedValidatorsCount {
 			t.Fatalf("Expected the count of collected signatures to equal the number of validators: [%v], but was: [%v]", expectedValidatorsCount, ethSignaturesCollected)
 		}


### PR DESCRIPTION
**Detailed description**:
* Fix: Timeout polls in Read-only service
* E2E: update messages received to 2mins instead of 1m30s
* E2E: increase to 25min

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

