### PR TITLE
feat(evm): retry mechanism on queries that might get stuck

### DIFF
--- a/app/clients/evm/client.go
+++ b/app/clients/evm/client.go
@@ -33,7 +33,7 @@ import (
 	"time"
 )
 
-// Used as a maximum amount of retries than need to be done when executing
+// Used as a maximum amount of retries that need to be done when executing
 // RetryBlockNumber, RetryFilterLogs
 const executionRetries = 10
 

--- a/app/clients/evm/client.go
+++ b/app/clients/evm/client.go
@@ -33,9 +33,9 @@ import (
 	"time"
 )
 
-// Used to as a maximum amount of retries than need to be done when executing
+// Used as a maximum amount of retries than need to be done when executing
 // RetryBlockNumber, RetryFilterLogs
-const executionRetries = 5
+const executionRetries = 10
 
 // Client EVM JSON RPC Client
 type Client struct {

--- a/app/clients/evm/client.go
+++ b/app/clients/evm/client.go
@@ -162,13 +162,13 @@ func (ec Client) BlockConfirmations() uint64 {
 
 // RetryBlockNumber returns the most recent block number
 // Uses a retry mechanism in case the filter query is stuck
-func (ec Client) RetryBlockNumber(ctx context.Context) (uint64, error) {
+func (ec Client) RetryBlockNumber() (uint64, error) {
 	blockNumberFunc := func() <-chan retry.Result {
 		r := make(chan retry.Result)
 		go func() {
 			defer close(r)
 
-			block, err := ec.BlockNumber(ctx)
+			block, err := ec.BlockNumber(context.Background())
 			r <- retry.Result{
 				Value: block,
 				Error: err,

--- a/app/clients/evm/client.go
+++ b/app/clients/evm/client.go
@@ -25,11 +25,17 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
+	"github.com/limechain/hedera-eth-bridge-validator/app/domain/service"
+	"github.com/limechain/hedera-eth-bridge-validator/app/model/retry"
 	"github.com/limechain/hedera-eth-bridge-validator/config"
 	log "github.com/sirupsen/logrus"
 	"math/big"
 	"time"
 )
+
+// Used to as a maximum amount of retries than need to be done when executing
+// RetryBlockNumber, RetryFilterLogs
+const executionRetries = 5
 
 // Client EVM JSON RPC Client
 type Client struct {
@@ -152,6 +158,68 @@ func (ec *Client) GetPrivateKey() string {
 
 func (ec Client) BlockConfirmations() uint64 {
 	return ec.config.BlockConfirmations
+}
+
+// RetryBlockNumber returns the most recent block number
+// Uses a retry mechanism in case the filter query is stuck
+func (ec Client) RetryBlockNumber(ctx context.Context) (uint64, error) {
+	blockNumberFunc := func() <-chan retry.Result {
+		r := make(chan retry.Result)
+		go func() {
+			defer close(r)
+
+			block, err := ec.BlockNumber(ctx)
+			r <- retry.Result{
+				Value: block,
+				Error: err,
+			}
+		}()
+
+		return r
+	}
+
+	result, err := service.Retry(blockNumberFunc, executionRetries)
+	if err != nil {
+		return 0, err
+	}
+
+	block, ok := result.(uint64)
+	if !ok {
+		return 0, errors.New(fmt.Sprintf("failed to cast block [%v]", result))
+	}
+
+	return block, nil
+}
+
+// RetryFilterLogs returns the logs from the input query
+// Uses a retry mechanism in case the filter query is stuck
+func (ec Client) RetryFilterLogs(query ethereum.FilterQuery) ([]types.Log, error) {
+	filterLogsFunc := func() <-chan retry.Result {
+		r := make(chan retry.Result)
+		go func() {
+			defer close(r)
+
+			logs, err := ec.FilterLogs(context.Background(), query)
+			r <- retry.Result{
+				Value: logs,
+				Error: err,
+			}
+		}()
+
+		return r
+	}
+
+	result, err := service.Retry(filterLogsFunc, executionRetries)
+	if err != nil {
+		return nil, err
+	}
+
+	logs, ok := result.([]types.Log)
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("failed to cast logs [%v]", result))
+	}
+
+	return logs, nil
 }
 
 func (ec *Client) WaitForConfirmations(raw types.Log) error {

--- a/app/domain/client/evm.go
+++ b/app/domain/client/evm.go
@@ -41,4 +41,10 @@ type EVM interface {
 	// GetPrivateKey retrieves private key used for the specific EVM Client
 	GetPrivateKey() string
 	BlockConfirmations() uint64
+	// RetryBlockNumber returns the most recent block number
+	// Uses a retry mechanism in case the filter query is stuck
+	RetryBlockNumber(ctx context.Context) (uint64, error)
+	// RetryFilterLogs returns the logs from the input query
+	// Uses a retry mechanism in case the filter query is stuck
+	RetryFilterLogs(query ethereum.FilterQuery) ([]types.Log, error)
 }

--- a/app/domain/client/evm.go
+++ b/app/domain/client/evm.go
@@ -43,7 +43,7 @@ type EVM interface {
 	BlockConfirmations() uint64
 	// RetryBlockNumber returns the most recent block number
 	// Uses a retry mechanism in case the filter query is stuck
-	RetryBlockNumber(ctx context.Context) (uint64, error)
+	RetryBlockNumber() (uint64, error)
 	// RetryFilterLogs returns the logs from the input query
 	// Uses a retry mechanism in case the filter query is stuck
 	RetryFilterLogs(query ethereum.FilterQuery) ([]types.Log, error)

--- a/app/domain/service/retry.go
+++ b/app/domain/service/retry.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"github.com/limechain/hedera-eth-bridge-validator/app/model/retry"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+var (
+	sleepPeriod  = 5 * time.Second
+	timeoutError = errors.New(fmt.Sprintf("Timeout after [%d]", sleepPeriod))
+)
+
+// timeout is a function that returns an error after sleepPeriod.
+func timeout() <-chan retry.Result {
+	r := make(chan retry.Result)
+
+	go func() {
+		defer close(r)
+
+		time.Sleep(sleepPeriod)
+		r <- retry.Result{
+			Value: nil,
+			Error: timeoutError,
+		}
+	}()
+
+	return r
+}
+
+// Retry executes two functions in race condition ({@param executionFunction} and timeout function).
+// It takes the first result from both functions.
+// If timeout function finishes first, it will retry the same mechanism {@param retries} times.
+// If {@param executionFunction} finishes first, it will directly resolve its result.
+// This function finds usability in the execution of EVM queries, which from time to time do not return response -
+// the query is stuck forever and breaks the business logic. This way, if the query takes more than sleepPeriod, it will
+// retry the query {@param retries} times.
+// If {@param retries} is reached, it will return an error.
+func Retry(executionFunction func() <-chan retry.Result, retries int) (interface{}, error) {
+	times := 0
+	var retryFunction func() (interface{}, error)
+
+	retryFunction = func() (interface{}, error) {
+		var executionResult retry.Result
+		select {
+		case executionResult = <-timeout():
+		case executionResult = <-executionFunction():
+		}
+		times++
+		if times >= retries {
+			log.Warnf("Function execution timeouted. [%d/%d] tries.", times, retries)
+			return 0, errors.New("too many retries")
+		}
+
+		if executionResult.Error != nil {
+			if errors.Is(executionResult.Error, timeoutError) {
+				log.Warnf("Function execution timeout. [%d/%d] tries.", times, retries)
+				return retryFunction()
+			}
+			return nil, executionResult.Error
+		}
+
+		return executionResult.Value, executionResult.Error
+	}
+
+	return retryFunction()
+}

--- a/app/model/retry/retry.go
+++ b/app/model/retry/retry.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package retry
+
+// Result serves as model, used as a result execution of a functions
+// related to retry mechanisms.
+type Result struct {
+	Value interface{}
+	Error error
+}

--- a/app/process/watcher/evm/watcher.go
+++ b/app/process/watcher/evm/watcher.go
@@ -84,7 +84,7 @@ func NewWatcher(
 	validator bool,
 	pollingInterval time.Duration,
 	maxLogsBlocks int64) *Watcher {
-	currentBlock, err := evmClient.RetryBlockNumber(context.Background())
+	currentBlock, err := evmClient.RetryBlockNumber()
 	if err != nil {
 		log.Fatalf("Could not retrieve latest block. Error: [%s].", err)
 	}
@@ -189,7 +189,7 @@ func (ew Watcher) beginWatching(queue qi.Queue) {
 			continue
 		}
 
-		currentBlock, err := ew.evmClient.RetryBlockNumber(context.Background())
+		currentBlock, err := ew.evmClient.RetryBlockNumber()
 		if err != nil {
 			ew.logger.Errorf("Failed to retrieve latest block number. Error [%s]", err)
 			time.Sleep(ew.sleepDuration)

--- a/app/process/watcher/evm/watcher.go
+++ b/app/process/watcher/evm/watcher.go
@@ -84,7 +84,7 @@ func NewWatcher(
 	validator bool,
 	pollingInterval time.Duration,
 	maxLogsBlocks int64) *Watcher {
-	currentBlock, err := evmClient.BlockNumber(context.Background())
+	currentBlock, err := evmClient.RetryBlockNumber(context.Background())
 	if err != nil {
 		log.Fatalf("Could not retrieve latest block. Error: [%s].", err)
 	}
@@ -189,7 +189,7 @@ func (ew Watcher) beginWatching(queue qi.Queue) {
 			continue
 		}
 
-		currentBlock, err := ew.evmClient.BlockNumber(context.Background())
+		currentBlock, err := ew.evmClient.RetryBlockNumber(context.Background())
 		if err != nil {
 			ew.logger.Errorf("Failed to retrieve latest block number. Error [%s]", err)
 			time.Sleep(ew.sleepDuration)
@@ -218,16 +218,16 @@ func (ew Watcher) beginWatching(queue qi.Queue) {
 }
 
 func (ew Watcher) processLogs(fromBlock, endBlock int64, queue qi.Queue) error {
-	query := &ethereum.FilterQuery{
+	query := ethereum.FilterQuery{
 		FromBlock: new(big.Int).SetInt64(fromBlock),
 		ToBlock:   new(big.Int).SetInt64(endBlock),
 		Addresses: ew.filterConfig.addresses,
 		Topics:    ew.filterConfig.topics,
 	}
 
-	logs, err := ew.evmClient.FilterLogs(context.Background(), *query)
+	logs, err := ew.evmClient.RetryFilterLogs(query)
 	if err != nil {
-		ew.logger.Errorf("Failed to to filter logs. Error: [%s]", err)
+		ew.logger.Errorf("Failed to filter logs. Error: [%s]", err)
 		return err
 	}
 

--- a/app/process/watcher/evm/watcher_test.go
+++ b/app/process/watcher/evm/watcher_test.go
@@ -458,7 +458,7 @@ func TestNewWatcher(t *testing.T) {
 	mocks.Setup()
 
 	mocks.MStatusRepository.On("Get", mock.Anything).Return(int64(0), nil)
-	mocks.MEVMClient.On("BlockNumber", mock.Anything).Return(uint64(10), nil)
+	mocks.MEVMClient.On("RetryBlockNumber").Return(uint64(10), nil)
 	mocks.MEVMClient.On("BlockConfirmations", mock.Anything).Return(uint64(5))
 
 	abi, err := abi.JSON(strings.NewReader(router.RouterABI))
@@ -532,7 +532,7 @@ func Test_ProcessLogs_ParseBurnLogFails(t *testing.T) {
 		Topics:  topics,
 	}
 
-	mocks.MEVMClient.On("FilterLogs", context.Background(), *query).
+	mocks.MEVMClient.On("RetryFilterLogs", *query).
 		Return([]types.Log{
 			{
 				Topics: []common.Hash{
@@ -573,7 +573,7 @@ func Test_ProcessLogs_ParseLockLogFails(t *testing.T) {
 		Topics:  topics,
 	}
 
-	mocks.MEVMClient.On("FilterLogs", context.Background(), *query).
+	mocks.MEVMClient.On("RetryFilterLogs", *query).
 		Return([]types.Log{
 			{
 				Topics: []common.Hash{
@@ -614,7 +614,7 @@ func Test_ProcessLogs_FilterLogsFails(t *testing.T) {
 		Topics:  topics,
 	}
 
-	mocks.MEVMClient.On("FilterLogs", context.Background(), *query).
+	mocks.MEVMClient.On("RetryFilterLogs", *query).
 		Return([]types.Log{}, errors.New("some-error"))
 
 	w.processLogs(0, 5, mocks.MQueue)
@@ -644,7 +644,7 @@ func Test_ProcessLogs_RepoUpdateFails(t *testing.T) {
 	}
 	expectedErr := errors.New("some-error")
 
-	mocks.MEVMClient.On("FilterLogs", context.Background(), *query).
+	mocks.MEVMClient.On("RetryFilterLogs", *query).
 		Return([]types.Log{}, nil)
 	mocks.MStatusRepository.On("Update", mocks.MBridgeContractService.Address().String(), int64(1)).Return(expectedErr)
 	res := w.processLogs(0, 0, mocks.MQueue)

--- a/test/mocks/evm-client/evm_client_mock.go
+++ b/test/mocks/evm-client/evm_client_mock.go
@@ -50,6 +50,26 @@ func (m *MockEVMClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) 
 	return args.Get(0).([]types.Log), args.Get(1).(error)
 }
 
+func (m *MockEVMClient) RetryBlockNumber() (uint64, error) {
+	args := m.Called()
+
+	if args.Get(1) == nil {
+		return args.Get(0).(uint64), nil
+	}
+
+	return args.Get(0).(uint64), args.Get(1).(error)
+}
+
+func (m *MockEVMClient) RetryFilterLogs(q ethereum.FilterQuery) ([]types.Log, error) {
+	args := m.Called(q)
+
+	if args.Get(1) == nil {
+		return args.Get(0).([]types.Log), nil
+	}
+
+	return args.Get(0).([]types.Log), args.Get(1).(error)
+}
+
 func (m *MockEVMClient) ChainID(ctx context.Context) (*big.Int, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil && args.Get(1) == nil {


### PR DESCRIPTION
**Detailed description**:
* Introduce a retry mechanism for EVM queries that might get stuck - no response to be returned, thus breaking the business logic.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:
E2E tests won't pass as Hedera testnet currently has an outage.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

