### PR TITLE
fix(evm-watchers): duplicate addresses on different networks

### DIFF
--- a/app/process/watcher/evm/watcher.go
+++ b/app/process/watcher/evm/watcher.go
@@ -44,7 +44,12 @@ import (
 )
 
 type Watcher struct {
-	repository    repository.Status
+	repository repository.Status
+	// A unique database identifier, used as a key to track the progress
+	// of the given EVM watcher. Given that addresses between different
+	// EVM networks might be the same, a concatenation between
+	// <chain-id>-<contract-address> removes possible duplication.
+	dbIdentifier  string
 	contracts     service.Contracts
 	evmClient     client.EVM
 	logger        *log.Entry
@@ -80,6 +85,7 @@ func NewWatcher(
 	contracts service.Contracts,
 	evmClient client.EVM,
 	mappings c.Assets,
+	dbIdentifier string,
 	startBlock int64,
 	validator bool,
 	pollingInterval time.Duration,
@@ -132,31 +138,32 @@ func NewWatcher(
 	}
 
 	if startBlock == 0 {
-		_, err := repository.Get(contracts.Address().String())
+		_, err := repository.Get(dbIdentifier)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				err := repository.Create(contracts.Address().String(), int64(targetBlock))
+				err := repository.Create(dbIdentifier, int64(targetBlock))
 				if err != nil {
-					log.Fatalf("[%s] - Failed to create Transfer Watcher timestamp. Error: [%s]", contracts.Address(), err)
+					log.Fatalf("[%s] - Failed to create Transfer Watcher timestamp. Error: [%s]", dbIdentifier, err)
 				}
-				log.Tracef("[%s] - Created new Transfer Watcher timestamp [%s]", contracts.Address(), timestamp.ToHumanReadable(int64(targetBlock)))
+				log.Tracef("[%s] - Created new Transfer Watcher timestamp [%s]", dbIdentifier, timestamp.ToHumanReadable(int64(targetBlock)))
 			} else {
-				log.Fatalf("[%s] - Failed to fetch last Transfer Watcher timestamp. Error: [%s]", contracts.Address(), err)
+				log.Fatalf("[%s] - Failed to fetch last Transfer Watcher timestamp. Error: [%s]", dbIdentifier, err)
 			}
 		}
 	} else {
-		err := repository.Update(contracts.Address().String(), startBlock)
+		err := repository.Update(dbIdentifier, startBlock)
 		if err != nil {
-			log.Fatalf("[%s] - Failed to update Transfer Watcher Status timestamp. Error [%s]", contracts.Address(), err)
+			log.Fatalf("[%s] - Failed to update Transfer Watcher Status timestamp. Error [%s]", dbIdentifier, err)
 		}
 		targetBlock = uint64(startBlock)
-		log.Tracef("[%s] - Updated Transfer Watcher timestamp to [%s]", contracts.Address(), timestamp.ToHumanReadable(startBlock))
+		log.Tracef("[%s] - Updated Transfer Watcher timestamp to [%s]", dbIdentifier, timestamp.ToHumanReadable(startBlock))
 	}
 	return &Watcher{
 		repository:    repository,
+		dbIdentifier:  dbIdentifier,
 		contracts:     contracts,
 		evmClient:     evmClient,
-		logger:        c.GetLoggerFor(fmt.Sprintf("EVM Router Watcher [%s]", contracts.Address())),
+		logger:        c.GetLoggerFor(fmt.Sprintf("EVM Router Watcher [%s]", dbIdentifier)),
 		mappings:      mappings,
 		targetBlock:   targetBlock,
 		validator:     validator,
@@ -168,11 +175,11 @@ func NewWatcher(
 func (ew *Watcher) Watch(queue qi.Queue) {
 	go ew.beginWatching(queue)
 
-	ew.logger.Infof("Listening for events at contract [%s]", ew.contracts.Address())
+	ew.logger.Infof("Listening for events at contract [%s]", ew.dbIdentifier)
 }
 
 func (ew Watcher) beginWatching(queue qi.Queue) {
-	fromBlock, err := ew.repository.Get(ew.contracts.Address().String())
+	fromBlock, err := ew.repository.Get(ew.dbIdentifier)
 	if err != nil {
 		ew.logger.Errorf("Failed to retrieve EVM Watcher Status fromBlock. Error: [%s]", err)
 		time.Sleep(ew.sleepDuration)
@@ -183,7 +190,7 @@ func (ew Watcher) beginWatching(queue qi.Queue) {
 	ew.logger.Infof("Processing events from [%d]", fromBlock)
 
 	for {
-		fromBlock, err := ew.repository.Get(ew.contracts.Address().String())
+		fromBlock, err := ew.repository.Get(ew.dbIdentifier)
 		if err != nil {
 			ew.logger.Errorf("Failed to retrieve EVM Watcher Status fromBlock. Error: [%s]", err)
 			continue
@@ -258,7 +265,7 @@ func (ew Watcher) processLogs(fromBlock, endBlock int64, queue qi.Queue) error {
 	// so that processing of duplicate events does not occur
 	blockToBeUpdated := endBlock + 1
 
-	err = ew.repository.Update(ew.contracts.Address().String(), blockToBeUpdated)
+	err = ew.repository.Update(ew.dbIdentifier, blockToBeUpdated)
 	if err != nil {
 		ew.logger.Errorf("Failed to update latest processed block [%d]. Error: [%s]", blockToBeUpdated, err)
 		return err

--- a/app/process/watcher/evm/watcher_test.go
+++ b/app/process/watcher/evm/watcher_test.go
@@ -56,6 +56,7 @@ var (
 	}
 	hederaAcc, _ = hedera.AccountIDFromString("0.0.123456")
 	hederaBytes  = hederaAcc.ToBytes()
+	dbIdentifier = "3-0x0000000000000000000000000000000000000001"
 
 	networks = map[int64]*parser.Network{
 		0: {
@@ -497,7 +498,8 @@ func TestNewWatcher(t *testing.T) {
 		repository:    mocks.MStatusRepository,
 		contracts:     mocks.MBridgeContractService,
 		evmClient:     mocks.MEVMClient,
-		logger:        config.GetLoggerFor("EVM Router Watcher [0x0000000000000000000000000000000000000000]"),
+		dbIdentifier:  dbIdentifier,
+		logger:        config.GetLoggerFor(fmt.Sprintf("EVM Router Watcher [%s]", dbIdentifier)),
 		mappings:      assets,
 		validator:     true,
 		targetBlock:   5,
@@ -505,7 +507,7 @@ func TestNewWatcher(t *testing.T) {
 		filterConfig:  filterConfig,
 	}
 
-	assert.EqualValues(t, w, NewWatcher(mocks.MStatusRepository, mocks.MBridgeContractService, mocks.MEVMClient, assets, 0, true, 15, 220))
+	assert.EqualValues(t, w, NewWatcher(mocks.MStatusRepository, mocks.MBridgeContractService, mocks.MEVMClient, assets, dbIdentifier, 0, true, 15, 220))
 }
 
 // TODO: Test_NewWatcher_Fails
@@ -546,7 +548,7 @@ func Test_ProcessLogs_ParseBurnLogFails(t *testing.T) {
 			burnHash,
 		},
 	}).Return(burnLog, errors.New("some-error"))
-	mocks.MStatusRepository.On("Update", mocks.MBridgeContractService.Address().String(), int64(1)).Return(nil)
+	mocks.MStatusRepository.On("Update", dbIdentifier, int64(1)).Return(nil)
 	w.processLogs(0, 0, mocks.MQueue)
 	mocks.MQueue.AssertNotCalled(t, "Push", mock.Anything)
 }
@@ -587,7 +589,7 @@ func Test_ProcessLogs_ParseLockLogFails(t *testing.T) {
 			lockHash,
 		},
 	}).Return(lockLog, errors.New("some-error"))
-	mocks.MStatusRepository.On("Update", mocks.MBridgeContractService.Address().String(), int64(1)).Return(nil)
+	mocks.MStatusRepository.On("Update", dbIdentifier, int64(1)).Return(nil)
 	w.processLogs(0, 0, mocks.MQueue)
 	mocks.MQueue.AssertNotCalled(t, "Push", mock.Anything)
 }
@@ -646,7 +648,7 @@ func Test_ProcessLogs_RepoUpdateFails(t *testing.T) {
 
 	mocks.MEVMClient.On("RetryFilterLogs", *query).
 		Return([]types.Log{}, nil)
-	mocks.MStatusRepository.On("Update", mocks.MBridgeContractService.Address().String(), int64(1)).Return(expectedErr)
+	mocks.MStatusRepository.On("Update", dbIdentifier, int64(1)).Return(expectedErr)
 	res := w.processLogs(0, 0, mocks.MQueue)
 	assert.Equal(t, expectedErr, res)
 }
@@ -662,6 +664,7 @@ func setup() {
 		repository:    mocks.MStatusRepository,
 		contracts:     mocks.MBridgeContractService,
 		evmClient:     mocks.MEVMClient,
+		dbIdentifier:  dbIdentifier,
 		logger:        config.GetLoggerFor("EVM Router Watcher [0x0000000000000000000000000000000000000000]"),
 		mappings:      config.LoadAssets(networks),
 		validator:     true,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,12 +129,19 @@ func initializeServerPairs(server *server.Server, services *Services, repositori
 		if err != nil {
 			panic(err)
 		}
+		contractService := services.contractServices[chain.Int64()]
+		// Given that addresses between different
+		// EVM networks might be the same, a concatenation between
+		// <chain-id>-<contract-address> removes possible duplication.
+		dbIdentifier := fmt.Sprintf("%d-%s", chain.Int64(), contractService.Address().String())
+
 		server.AddWatcher(
 			evm.NewWatcher(
 				repositories.transferStatus,
-				services.contractServices[chain.Int64()],
+				contractService,
 				evmClient,
 				configuration.Bridge.Assets,
+				dbIdentifier,
 				configuration.Node.Clients.Evm[chain.Int64()].StartBlock,
 				configuration.Node.Validator,
 				configuration.Node.Clients.Evm[chain.Int64()].PollingInterval,


### PR DESCRIPTION
**Detailed description**:
* Fix db key for EVM networks to be `<chain-id>-<contract-address>` instead of `<contract-address>`, due to possible duplication of addresses between different networks.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

