### PR TITLE
In Prometheus Service changing the NewGaugeMetric to check first if g…

### DIFF
--- a/app/domain/service/prometheus.go
+++ b/app/domain/service/prometheus.go
@@ -3,10 +3,8 @@ package service
 import "github.com/prometheus/client_golang/prometheus"
 
 type Prometheus interface {
-	// NewGaugeMetric creates new Gauge Metric
-	NewGaugeMetric(name string, help string) prometheus.Gauge
-	// RegisterGaugeMetric registering new Gauge Metric
-	RegisterGaugeMetric(gauge prometheus.Gauge)
+	// CreateAndRegisterGaugeMetric creates new Gauge Metric and registers it in Prometheus
+	CreateAndRegisterGaugeMetric(name string, help string) prometheus.Gauge
 	// GetGauge retrieves Gauge by name with flag for existence
 	GetGauge(name string) prometheus.Gauge
 }

--- a/app/process/handler/message/handler.go
+++ b/app/process/handler/message/handler.go
@@ -59,7 +59,7 @@ func NewHandler(
 
 	var participationRate prometheus.Gauge
 	if enableMonitoring && prometheusService != nil {
-		participationRate = prometheusService.GetGauge(constants.ValidatorsParticipationRateGaugeName)
+		participationRate = prometheusService.NewGaugeMetric(constants.ValidatorsParticipationRateGaugeName, constants.ValidatorsParticipationRateGaugeHelp)
 	}
 
 	return &Handler{

--- a/app/process/handler/message/handler.go
+++ b/app/process/handler/message/handler.go
@@ -59,7 +59,7 @@ func NewHandler(
 
 	var participationRate prometheus.Gauge
 	if enableMonitoring && prometheusService != nil {
-		participationRate = prometheusService.NewGaugeMetric(constants.ValidatorsParticipationRateGaugeName, constants.ValidatorsParticipationRateGaugeHelp)
+		participationRate = prometheusService.CreateAndRegisterGaugeMetric(constants.ValidatorsParticipationRateGaugeName, constants.ValidatorsParticipationRateGaugeHelp)
 	}
 
 	return &Handler{

--- a/app/process/handler/message/handler_test.go
+++ b/app/process/handler/message/handler_test.go
@@ -154,7 +154,7 @@ func setup() {
 	gauge := prometheus.NewGauge(opts)
 
 	mocks.MPrometheusService.On(
-		"NewGaugeMetric",
+		"CreateAndRegisterGaugeMetric",
 		constants.ValidatorsParticipationRateGaugeName,
 		constants.ValidatorsParticipationRateGaugeHelp).Return(gauge)
 	mocks.MPrometheusService.On("GetGauge", constants.ValidatorsParticipationRateGaugeName).Return(gauge)

--- a/app/process/watcher/prometheus/watcher.go
+++ b/app/process/watcher/prometheus/watcher.go
@@ -51,8 +51,8 @@ func NewWatcher(
 	)
 
 	if enableMonitoring && prometheusService != nil {
-		payerAccountBalanceGauge = prometheusService.GetGauge(constants.FeeAccountAmountGaugeName)
-		bridgeAccountBalanceGauge = prometheusService.GetGauge(constants.BridgeAccountAmountGaugeName)
+		payerAccountBalanceGauge = prometheusService.NewGaugeMetric(constants.FeeAccountAmountGaugeName, constants.FeeAccountAmountGaugeHelp)
+		bridgeAccountBalanceGauge = prometheusService.NewGaugeMetric(constants.BridgeAccountAmountGaugeName, constants.BridgeAccountAmountGaugeHelp)
 	}
 
 	return &Watcher{

--- a/app/process/watcher/prometheus/watcher.go
+++ b/app/process/watcher/prometheus/watcher.go
@@ -51,8 +51,8 @@ func NewWatcher(
 	)
 
 	if enableMonitoring && prometheusService != nil {
-		payerAccountBalanceGauge = prometheusService.NewGaugeMetric(constants.FeeAccountAmountGaugeName, constants.FeeAccountAmountGaugeHelp)
-		bridgeAccountBalanceGauge = prometheusService.NewGaugeMetric(constants.BridgeAccountAmountGaugeName, constants.BridgeAccountAmountGaugeHelp)
+		payerAccountBalanceGauge = prometheusService.CreateAndRegisterGaugeMetric(constants.FeeAccountAmountGaugeName, constants.FeeAccountAmountGaugeHelp)
+		bridgeAccountBalanceGauge = prometheusService.CreateAndRegisterGaugeMetric(constants.BridgeAccountAmountGaugeName, constants.BridgeAccountAmountGaugeHelp)
 	}
 
 	return &Watcher{

--- a/app/services/prometheus/service.go
+++ b/app/services/prometheus/service.go
@@ -47,7 +47,7 @@ func NewService(
 	}
 }
 
-func (s Service) NewGaugeMetric(name string, help string) prometheus.Gauge {
+func (s Service) CreateAndRegisterGaugeMetric(name string, help string) prometheus.Gauge {
 	if gauge, exist := s.gauges[name]; exist {
 		return gauge
 	}
@@ -57,13 +57,11 @@ func (s Service) NewGaugeMetric(name string, help string) prometheus.Gauge {
 		Help: help,
 	}
 	gauge := prometheus.NewGauge(opts)
+	// Registering the Gauge
+	prometheus.MustRegister(gauge)
 	s.gauges[name] = gauge
 
 	return gauge
-}
-
-func (s Service) RegisterGaugeMetric(gauge prometheus.Gauge) {
-	prometheus.MustRegister(gauge)
 }
 
 func (s Service) GetGauge(name string) prometheus.Gauge {

--- a/app/services/prometheus/service.go
+++ b/app/services/prometheus/service.go
@@ -48,6 +48,10 @@ func NewService(
 }
 
 func (s Service) NewGaugeMetric(name string, help string) prometheus.Gauge {
+	if gauge, exist := s.gauges[name]; exist {
+		return gauge
+	}
+
 	opts := prometheus.GaugeOpts{
 		Name: name,
 		Help: help,

--- a/app/services/prometheus/service_test.go
+++ b/app/services/prometheus/service_test.go
@@ -29,27 +29,22 @@ func Test_New(t *testing.T) {
 	assert.Equal(t, service, actualService)
 }
 
-func Test_NewGaugeMetric(t *testing.T) {
+func Test_CreateAndRegisterGaugeMetric(t *testing.T) {
 	setup()
 
-	gauge = service.NewGaugeMetric(gaugeName, gaugeHelp)
+	gauge = service.CreateAndRegisterGaugeMetric(gaugeName, gaugeHelp)
+	defer prometheus.Unregister(gauge)
 	gaugeInMapping := service.GetGauge(gaugeName)
 
 	assert.NotNil(t, gauge)
 	assert.NotNil(t, gaugeInMapping)
 }
 
-func Test_RegisterGaugeMetric(t *testing.T) {
-	setup()
-
-	gauge = service.NewGaugeMetric(gaugeName, gaugeHelp)
-	service.RegisterGaugeMetric(gauge)
-}
-
 func Test_GetGauge(t *testing.T) {
 	setup()
 
-	gauge = service.NewGaugeMetric(gaugeName, gaugeHelp)
+	gauge = service.CreateAndRegisterGaugeMetric(gaugeName, gaugeHelp)
+	defer prometheus.Unregister(gauge)
 	gaugeInMapping := service.GetGauge(gaugeName)
 
 	assert.NotNil(t, gaugeInMapping)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,7 +83,6 @@ func main() {
 
 func initializeMonitoring(prometheusService service.Prometheus, s *server.Server, configuration config.Config, mirrorNode client.MirrorNode) {
 	if configuration.Node.Monitoring.Enable {
-		initializeAndRegisterGauges(prometheusService)
 		initializePrometheusWatcher(s, configuration, mirrorNode, prometheusService)
 	} else {
 		log.Infoln("Monitoring is disabled. No metrics will be added.")
@@ -192,19 +191,6 @@ func initializeServerPairs(server *server.Server, services *Services, repositori
 		services.transfers,
 		services.readOnly))
 	server.AddHandler(constants.ReadOnlyTransferSave, rthh.NewHandler(services.transfers))
-}
-
-func initializeAndRegisterGauges(prometheusService service.Prometheus) {
-
-	// Initialize the Gauges //
-	FeeAccountAmountGauge := prometheusService.NewGaugeMetric(constants.FeeAccountAmountGaugeName, constants.FeeAccountAmountGaugeHelp)
-	BridgeAccountAmountGauge := prometheusService.NewGaugeMetric(constants.BridgeAccountAmountGaugeName, constants.BridgeAccountAmountGaugeHelp)
-	ValidatorsParticipationRateGauge := prometheusService.NewGaugeMetric(constants.ValidatorsParticipationRateGaugeName, constants.ValidatorsParticipationRateGaugeHelp)
-
-	// Register the Gauges
-	prometheusService.RegisterGaugeMetric(FeeAccountAmountGauge)
-	prometheusService.RegisterGaugeMetric(BridgeAccountAmountGauge)
-	prometheusService.RegisterGaugeMetric(ValidatorsParticipationRateGauge)
 }
 
 func initializePrometheusWatcher(server *server.Server, configuration config.Config, client client.MirrorNode, prometheusService service.Prometheus) {

--- a/test/mocks/service/prometheus_service_mock.go
+++ b/test/mocks/service/prometheus_service_mock.go
@@ -25,16 +25,11 @@ type MockPrometheusService struct {
 	mock.Mock
 }
 
-// NewGaugeMetric creates new Gauge Metric
-func (mps *MockPrometheusService) NewGaugeMetric(name string, help string) prometheus.Gauge {
+// CreateAndRegisterGaugeMetric creates new Gauge Metric and registers it in Prometheus
+func (mps *MockPrometheusService) CreateAndRegisterGaugeMetric(name string, help string) prometheus.Gauge {
 	args := mps.Called(name, help)
 	result := args.Get(0).(prometheus.Gauge)
 	return result
-}
-
-// RegisterGaugeMetric registering new Gauge Metric
-func (mps *MockPrometheusService) RegisterGaugeMetric(gauge prometheus.Gauge) {
-	mps.Called(gauge)
 }
 
 // GetGauge retrieves Gauge by name with flag for existence


### PR DESCRIPTION
…auge exists to return it. Moving creation of Gauges of main.go to services which need them.

Signed-off-by: nnedkov-limechain <nikolay.nedkov@limechain.tech>

**Detailed description**:

**Which issue(s) this PR fixes**:
Fixes #355

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

