### PR TITLE
Making all usages of ChainIds/NetworkIds to be of type uint64.

### DIFF
--- a/app/domain/service/messages.go
+++ b/app/domain/service/messages.go
@@ -29,7 +29,7 @@ type Messages interface {
 	// (verifies input data against the corresponding Transaction record)
 	SanityCheckNftSignature(tm *proto.TopicEthNftSignatureMessage) (bool, error)
 	// ProcessSignature processes the signature message, verifying and updating all necessary fields in the DB
-	ProcessSignature(transferID, signature string, targetChainId, timestamp int64, authMsg []byte) error
+	ProcessSignature(transferID, signature string, targetChainId uint64, timestamp int64, authMsg []byte) error
 	// SignFungibleMessage signs a Fungible message based on Transfer
 	SignFungibleMessage(transfer model.Transfer) ([]byte, error)
 	// SignNftMessage signs an NFT messaged based on Transfer

--- a/app/domain/service/prometheus.go
+++ b/app/domain/service/prometheus.go
@@ -24,7 +24,7 @@ type Prometheus interface {
 	// CreateGaugeIfNotExists creates new Gauge Metric and registers it in Prometheus if not exists
 	CreateGaugeIfNotExists(opts prometheus.GaugeOpts) prometheus.Gauge
 	// CreateSuccessRateGaugeIfNotExists creates new Gauge Metric for Success Rate and registers it in Prometheus if not exists
-	CreateSuccessRateGaugeIfNotExists(transactionId string, sourceChainId int64, targetChainId int64, asset, metricNameSuffix, metricHelp string) (prometheus.Gauge, error)
+	CreateSuccessRateGaugeIfNotExists(transactionId string, sourceChainId, targetChainId uint64, asset, metricNameSuffix, metricHelp string) (prometheus.Gauge, error)
 	// GetGauge retrieves Gauge by name with flag for existence
 	GetGauge(name string) prometheus.Gauge
 	// DeleteGauge unregisters and deletes Gauge with the passed name

--- a/app/domain/service/transfers.go
+++ b/app/domain/service/transfers.go
@@ -26,7 +26,7 @@ import (
 type Transfers interface {
 	// SanityCheckTransfer performs any validation required prior to handling the transaction
 	// (memo, state proof verification)
-	SanityCheckTransfer(tx model.Transaction) (int64, string, error)
+	SanityCheckTransfer(tx model.Transaction) (uint64, string, error)
 	// InitiateNewTransfer Stores the incoming transfer message into the Database
 	// aware of already processed transfers
 	InitiateNewTransfer(tm transfer.Transfer) (*entity.Transfer, error)
@@ -48,8 +48,8 @@ type TransferData struct {
 	IsNft         bool     `json:"isNft"`
 	Recipient     string   `json:"recipient"`
 	RouterAddress string   `json:"routerAddress"`
-	SourceChainId int64    `json:"sourceChainId"`
-	TargetChainId int64    `json:"targetChainId"`
+	SourceChainId uint64   `json:"sourceChainId"`
+	TargetChainId uint64   `json:"targetChainId"`
 	SourceAsset   string   `json:"sourceAsset"`
 	NativeAsset   string   `json:"nativeAsset"`
 	TargetAsset   string   `json:"wrappedAsset"`

--- a/app/helper/hedera/scheduled_transaction.go
+++ b/app/helper/hedera/scheduled_transaction.go
@@ -25,11 +25,11 @@ import (
 // AwaitMultipleScheduledTransactions is meant to be used when you need to wait all the scheduled transactions to be mined.
 func AwaitMultipleScheduledTransactions(
 	outParams *OutParams,
-	sourceChainId int64,
-	targetChainId int64,
+	sourceChainId uint64,
+	targetChainId uint64,
 	asset string,
 	transferID string,
-	callback func(sourceChainId int64, targetChainId int64, nativeAsset string, transferID string, isTransferSuccessful bool)) {
+	callback func(sourceChainId, targetChainId uint64, nativeAsset string, transferID string, isTransferSuccessful bool)) {
 
 	if outParams.waitGroup == nil {
 		panic(fmt.Sprintf("[%v] Await group is nil. [AwaitMultipleScheduledTransactions]", transferID))

--- a/app/helper/metrics/helper.go
+++ b/app/helper/metrics/helper.go
@@ -55,7 +55,7 @@ func ConstructNameForMetric(sourceNetworkId, targetNetworkId uint64, tokenType, 
 
 // Success Rate Metrics //
 
-func CreateUserGetHisTokensIfNotExists(sourceChainId int64, targetChainId int64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) prometheus.Gauge {
+func CreateUserGetHisTokensIfNotExists(sourceChainId, targetChainId uint64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) prometheus.Gauge {
 	if !prometheusService.GetIsMonitoringEnabled() {
 		return nil
 	}
@@ -74,7 +74,7 @@ func CreateUserGetHisTokensIfNotExists(sourceChainId int64, targetChainId int64,
 	return gauge
 }
 
-func SetUserGetHisTokens(sourceChainId int64, targetChainId int64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) {
+func SetUserGetHisTokens(sourceChainId, targetChainId uint64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) {
 	if !prometheusService.GetIsMonitoringEnabled() {
 		return
 	}
@@ -84,7 +84,7 @@ func SetUserGetHisTokens(sourceChainId int64, targetChainId int64, asset string,
 	gauge.Set(1.0)
 }
 
-func CreateFeeTransferredIfNotExists(sourceChainId int64, targetChainId int64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) prometheus.Gauge {
+func CreateFeeTransferredIfNotExists(sourceChainId, targetChainId uint64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) prometheus.Gauge {
 	if !prometheusService.GetIsMonitoringEnabled() {
 		return nil
 	}
@@ -103,7 +103,7 @@ func CreateFeeTransferredIfNotExists(sourceChainId int64, targetChainId int64, a
 	return gauge
 }
 
-func SetFeeTransferred(sourceChainId int64, targetChainId int64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) {
+func SetFeeTransferred(sourceChainId, targetChainId uint64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) {
 	if !prometheusService.GetIsMonitoringEnabled() {
 		return
 	}
@@ -113,7 +113,7 @@ func SetFeeTransferred(sourceChainId int64, targetChainId int64, asset string, t
 	gauge.Set(1.0)
 }
 
-func CreateMajorityReachedIfNotExists(sourceChainId int64, targetChainId int64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) prometheus.Gauge {
+func CreateMajorityReachedIfNotExists(sourceChainId uint64, targetChainId uint64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) prometheus.Gauge {
 	if !prometheusService.GetIsMonitoringEnabled() {
 		return nil
 	}
@@ -133,7 +133,7 @@ func CreateMajorityReachedIfNotExists(sourceChainId int64, targetChainId int64, 
 	return gauge
 }
 
-func SetMajorityReached(sourceChainId int64, targetChainId int64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) {
+func SetMajorityReached(sourceChainId, targetChainId uint64, asset string, transferID string, prometheusService service.Prometheus, logger *log.Entry) {
 	if !prometheusService.GetIsMonitoringEnabled() {
 		return
 	}

--- a/app/model/auth-message/auth-message.go
+++ b/app/model/auth-message/auth-message.go
@@ -26,7 +26,7 @@ import (
 
 // EncodeFungibleBytesFrom returns the array of bytes representing an
 // authorisation ERC-20 Mint signature ready to be signed by EVM Private Key
-func EncodeFungibleBytesFrom(sourceChainId, targetChainId int64, txId, asset, receiverEthAddress, amount string) ([]byte, error) {
+func EncodeFungibleBytesFrom(sourceChainId, targetChainId uint64, txId, asset, receiverEthAddress, amount string) ([]byte, error) {
 	args, err := generateFungibleArguments()
 	if err != nil {
 		return nil, err
@@ -37,8 +37,8 @@ func EncodeFungibleBytesFrom(sourceChainId, targetChainId int64, txId, asset, re
 	}
 
 	bytesToHash, err := args.Pack(
-		big.NewInt(sourceChainId),
-		big.NewInt(targetChainId),
+		new(big.Int).SetUint64(sourceChainId),
+		new(big.Int).SetUint64(targetChainId),
 		[]byte(txId),
 		common.HexToAddress(asset),
 		common.HexToAddress(receiverEthAddress),
@@ -51,15 +51,15 @@ func EncodeFungibleBytesFrom(sourceChainId, targetChainId int64, txId, asset, re
 
 // EncodeNftBytesFrom returns the array of bytes representing an
 // authorisation ERC-721 NFT signature for Mint ready to be signed by EVM Private Key
-func EncodeNftBytesFrom(sourceChainId, targetChainId int64, txId, asset string, serialNum int64, metadata, receiverEthAddress string) ([]byte, error) {
+func EncodeNftBytesFrom(sourceChainId, targetChainId uint64, txId, asset string, serialNum int64, metadata, receiverEthAddress string) ([]byte, error) {
 	args, err := generateNftArguments()
 	if err != nil {
 		return nil, err
 	}
 
 	bytesToHash, err := args.Pack(
-		big.NewInt(sourceChainId),
-		big.NewInt(targetChainId),
+		new(big.Int).SetUint64(sourceChainId),
+		new(big.Int).SetUint64(targetChainId),
 		[]byte(txId),
 		common.HexToAddress(asset),
 		big.NewInt(serialNum),

--- a/app/model/auth-message/auth-message_test.go
+++ b/app/model/auth-message/auth-message_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	sourceChainId   = int64(0)
-	targetChainId   = int64(1)
+	sourceChainId   = 0
+	targetChainId   = 1
 	txId            = "0.0.123-123321-123321"
 	asset           = "0x00000"
 	receiverAddress = "0xsomeaddress"

--- a/app/model/transfer/transfer.go
+++ b/app/model/transfer/transfer.go
@@ -19,9 +19,9 @@ package transfer
 // Transfer serves as a model between Transfer Watcher and Handler
 type Transfer struct {
 	TransactionId string
-	SourceChainId int64
-	TargetChainId int64
-	NativeChainId int64
+	SourceChainId uint64
+	TargetChainId uint64
+	NativeChainId uint64
 	SourceAsset   string
 	TargetAsset   string
 	NativeAsset   string
@@ -35,7 +35,7 @@ type Transfer struct {
 
 // New instantiates Transfer struct ready for submission to the handler
 func New(txId string,
-	sourceChainId, targetChainId, nativeChainId int64,
+	sourceChainId, targetChainId, nativeChainId uint64,
 	receiver, sourceAsset, targetAsset, nativeAsset, amount string) *Transfer {
 	return &Transfer{
 		TransactionId: txId,
@@ -54,7 +54,7 @@ func New(txId string,
 // NewNft instantiates a Transfer, consisting of serial num and metadata for a given NFT
 func NewNft(
 	txId string,
-	sourceChainId, targetChainId, nativeChainId int64, receiver, sourceAsset, targetAsset, nativeAsset string, serialNum int64, metadata string) *Transfer {
+	sourceChainId, targetChainId, nativeChainId uint64, receiver, sourceAsset, targetAsset, nativeAsset string, serialNum int64, metadata string) *Transfer {
 	return &Transfer{
 		TransactionId: txId,
 		SourceChainId: sourceChainId,

--- a/app/model/transfer/transfer_test.go
+++ b/app/model/transfer/transfer_test.go
@@ -7,9 +7,9 @@ import (
 
 const (
 	txId          = "0.0.123123-123321-420"
-	sourceChainId = int64(0)
-	targetChainId = int64(1)
-	nativeChainId = int64(0)
+	sourceChainId = 0
+	targetChainId = 1
+	nativeChainId = 0
 	receiver      = "0xreceiver"
 	amount        = "100"
 	sourceAsset   = "0.0.123"

--- a/app/persistence/entity/transfer.go
+++ b/app/persistence/entity/transfer.go
@@ -20,9 +20,9 @@ import "database/sql"
 
 type Transfer struct {
 	TransactionID string `gorm:"primaryKey"`
-	SourceChainID int64
-	TargetChainID int64
-	NativeChainID int64
+	SourceChainID uint64
+	TargetChainID uint64
+	NativeChainID uint64
 	SourceAsset   string
 	TargetAsset   string
 	NativeAsset   string

--- a/app/process/handler/message/handler_test.go
+++ b/app/process/handler/message/handler_test.go
@@ -60,12 +60,12 @@ var (
 	}
 	assets               config.Assets
 	transactionTimestamp = int64(0)
-	authMsgBytes, _      = auth_message.EncodeFungibleBytesFrom(int64(tesm.SourceChainId), int64(tesm.TargetChainId), tesm.TransferID, tesm.Asset, tesm.Recipient, tesm.Amount)
+	authMsgBytes, _      = auth_message.EncodeFungibleBytesFrom(tesm.SourceChainId, tesm.TargetChainId, tesm.TransferID, tesm.Asset, tesm.Recipient, tesm.Amount)
 )
 
 func Test_NewHandler(t *testing.T) {
 	setup()
-	assert.Equal(t, h, NewHandler(topicId.String(), mocks.MTransferRepository, mocks.MMessageRepository, map[int64]service.Contracts{1: mocks.MBridgeContractService}, mocks.MMessageService, mocks.MPrometheusService, assets))
+	assert.Equal(t, h, NewHandler(topicId.String(), mocks.MTransferRepository, mocks.MMessageRepository, map[uint64]service.Contracts{1: mocks.MBridgeContractService}, mocks.MMessageService, mocks.MPrometheusService, assets))
 }
 
 func Test_Handle_Fails(t *testing.T) {
@@ -93,7 +93,7 @@ func Test_HandleSignatureMessage_SanityCheckIsNotValid(t *testing.T) {
 func Test_HandleSignatureMessage_ProcessSignatureFails(t *testing.T) {
 	setup()
 	mocks.MMessageService.On("SanityCheckFungibleSignature", tsm.GetFungibleSignatureMessage()).Return(true, nil)
-	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, int64(tsm.GetFungibleSignatureMessage().TargetChainId), transactionTimestamp, authMsgBytes).Return(errors.New("some-error"))
+	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, tsm.GetFungibleSignatureMessage().TargetChainId, transactionTimestamp, authMsgBytes).Return(errors.New("some-error"))
 	h.handleFungibleSignatureMessage(tsm.GetFungibleSignatureMessage(), transactionTimestamp)
 	mocks.MTransferRepository.AssertNotCalled(t, "Update", mock.Anything)
 	mocks.MMessageRepository.AssertNotCalled(t, "Get", mock.Anything)
@@ -103,7 +103,7 @@ func Test_HandleSignatureMessage_ProcessSignatureFails(t *testing.T) {
 func Test_HandleSignatureMessage_MajorityReached(t *testing.T) {
 	setup()
 	mocks.MMessageService.On("SanityCheckFungibleSignature", tsm.GetFungibleSignatureMessage()).Return(true, nil)
-	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, int64(tsm.GetFungibleSignatureMessage().TargetChainId), transactionTimestamp, authMsgBytes).Return(nil)
+	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, tsm.GetFungibleSignatureMessage().TargetChainId, transactionTimestamp, authMsgBytes).Return(nil)
 	mocks.MMessageRepository.On("Get", tsm.GetFungibleSignatureMessage().TransferID).Return([]entity.Message{{}, {}, {}}, nil)
 	mocks.MBridgeContractService.On("GetMembers").Return([]string{"", "", ""})
 	mocks.MBridgeContractService.On("HasValidSignaturesLength", big.NewInt(3)).Return(true, nil)
@@ -116,7 +116,7 @@ func Test_HandleSignatureMessage_MajorityReached(t *testing.T) {
 func Test_Handle(t *testing.T) {
 	setup()
 	mocks.MMessageService.On("SanityCheckFungibleSignature", tsm.GetFungibleSignatureMessage()).Return(true, nil)
-	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, int64(tsm.GetFungibleSignatureMessage().TargetChainId), transactionTimestamp, authMsgBytes).Return(nil)
+	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, tsm.GetFungibleSignatureMessage().TargetChainId, transactionTimestamp, authMsgBytes).Return(nil)
 	mocks.MMessageRepository.On("Get", tsm.GetFungibleSignatureMessage().TransferID).Return([]entity.Message{{}, {}, {}}, nil)
 	mocks.MBridgeContractService.On("GetMembers").Return([]string{"", "", ""})
 	mocks.MBridgeContractService.On("HasValidSignaturesLength", big.NewInt(3)).Return(true, nil)
@@ -129,7 +129,7 @@ func Test_Handle(t *testing.T) {
 func Test_HandleSignatureMessage_UpdateStatusCompleted_Fails(t *testing.T) {
 	setup()
 	mocks.MMessageService.On("SanityCheckFungibleSignature", tsm.GetFungibleSignatureMessage()).Return(true, nil)
-	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, int64(tsm.GetFungibleSignatureMessage().TargetChainId), transactionTimestamp, authMsgBytes).Return(nil)
+	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, tsm.GetFungibleSignatureMessage().TargetChainId, transactionTimestamp, authMsgBytes).Return(nil)
 	mocks.MMessageRepository.On("Get", tsm.GetFungibleSignatureMessage().TransferID).Return([]entity.Message{{}, {}, {}}, nil)
 	mocks.MBridgeContractService.On("GetMembers").Return([]string{"", "", ""})
 	mocks.MBridgeContractService.On("HasValidSignaturesLength", big.NewInt(3)).Return(true, nil)
@@ -142,7 +142,7 @@ func Test_HandleSignatureMessage_UpdateStatusCompleted_Fails(t *testing.T) {
 func Test_HandleSignatureMessage_CheckMajority_Fails(t *testing.T) {
 	setup()
 	mocks.MMessageService.On("SanityCheckFungibleSignature", tsm.GetFungibleSignatureMessage()).Return(true, nil)
-	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, int64(tsm.GetFungibleSignatureMessage().TargetChainId), transactionTimestamp, authMsgBytes).Return(nil)
+	mocks.MMessageService.On("ProcessSignature", tsm.GetFungibleSignatureMessage().TransferID, tsm.GetFungibleSignatureMessage().Signature, tsm.GetFungibleSignatureMessage().TargetChainId, transactionTimestamp, authMsgBytes).Return(nil)
 	mocks.MMessageRepository.On("Get", tsm.GetFungibleSignatureMessage().TransferID).Return([]entity.Message{{}, {}, {}}, errors.New("some-error"))
 	h.handleFungibleSignatureMessage(tsm.GetFungibleSignatureMessage(), transactionTimestamp)
 	mocks.MBridgeContractService.AssertNotCalled(t, "GetMembers")
@@ -157,7 +157,7 @@ func setup() {
 	h = &Handler{
 		transferRepository:     mocks.MTransferRepository,
 		messageRepository:      mocks.MMessageRepository,
-		contracts:              map[int64]service.Contracts{1: mocks.MBridgeContractService},
+		contracts:              map[uint64]service.Contracts{1: mocks.MBridgeContractService},
 		messages:               mocks.MMessageService,
 		logger:                 config.GetLoggerFor(fmt.Sprintf("Topic [%s] Handler", topicId.String())),
 		prometheusService:      mocks.MPrometheusService,

--- a/app/process/handler/read-only/fee-transfer/handler.go
+++ b/app/process/handler/read-only/fee-transfer/handler.go
@@ -225,7 +225,7 @@ func (fmh *Handler) startAwaitingFunctionsForMetrics(userOutParams *hederaHelper
 	)
 }
 
-func (fmh *Handler) onMinedFeeTransactionsSetMetrics(sourceChainId int64, targetChainId int64, nativeAsset string, transferID string, isTransferSuccessful bool) {
+func (fmh *Handler) onMinedFeeTransactionsSetMetrics(sourceChainId, targetChainId uint64, nativeAsset string, transferID string, isTransferSuccessful bool) {
 	if sourceChainId == constants.HederaNetworkId || isTransferSuccessful == false || !fmh.prometheusService.GetIsMonitoringEnabled() {
 		return
 	}
@@ -233,7 +233,7 @@ func (fmh *Handler) onMinedFeeTransactionsSetMetrics(sourceChainId int64, target
 	metrics.SetFeeTransferred(sourceChainId, targetChainId, nativeAsset, transferID, fmh.prometheusService, fmh.logger)
 }
 
-func (fmh *Handler) onMinedUserTransactionSetMetrics(sourceChainId int64, targetChainId int64, nativeAsset string, transferID string, isTransferSuccessful bool) {
+func (fmh *Handler) onMinedUserTransactionSetMetrics(sourceChainId, targetChainId uint64, nativeAsset string, transferID string, isTransferSuccessful bool) {
 	if sourceChainId == constants.HederaNetworkId || isTransferSuccessful == false || !fmh.prometheusService.GetIsMonitoringEnabled() {
 		return
 	}

--- a/app/process/handler/read-only/fee/handler.go
+++ b/app/process/handler/read-only/fee/handler.go
@@ -191,7 +191,7 @@ func (fmh Handler) Handle(payload interface{}) {
 	}
 }
 
-func (fmh *Handler) onMinedFeeTransactionsSetMetrics(sourceChainId int64, targetChainId int64, nativeAsset string, transferID string, isTransferSuccessful bool) {
+func (fmh *Handler) onMinedFeeTransactionsSetMetrics(sourceChainId, targetChainId uint64, nativeAsset string, transferID string, isTransferSuccessful bool) {
 	if sourceChainId != constants.HederaNetworkId || isTransferSuccessful == false || !fmh.prometheusService.GetIsMonitoringEnabled() {
 		return
 	}

--- a/app/process/watcher/evm/watcher.go
+++ b/app/process/watcher/evm/watcher.go
@@ -326,9 +326,9 @@ func (ew *Watcher) handleMintLog(eventLog *router.RouterMint) {
 		return
 	}
 	transactionId := string(eventLog.TransactionId)
-	sourceChainId := eventLog.SourceChain.Int64()
-	targetChainId := chain.Int64()
-	oppositeToken := ew.mappings.GetOppositeAsset(uint64(sourceChainId), uint64(targetChainId), eventLog.Token.String())
+	sourceChainId := eventLog.SourceChain.Uint64()
+	targetChainId := chain.Uint64()
+	oppositeToken := ew.mappings.GetOppositeAsset(sourceChainId, targetChainId, eventLog.Token.String())
 
 	metrics.SetUserGetHisTokens(sourceChainId, targetChainId, oppositeToken, transactionId, ew.prometheusService, ew.logger)
 }
@@ -353,14 +353,14 @@ func (ew *Watcher) handleBurnLog(eventLog *router.RouterBurn, q qi.Queue) {
 		return
 	}
 
-	nativeAsset := ew.mappings.WrappedToNative(eventLog.Token.String(), chain.Int64())
+	nativeAsset := ew.mappings.WrappedToNative(eventLog.Token.String(), chain.Uint64())
 	if nativeAsset == nil {
 		ew.logger.Errorf("[%s] - Failed to retrieve native asset of [%s].", eventLog.Raw.TxHash, eventLog.Token)
 		return
 	}
 
-	sourceChainId := chain.Int64()
-	targetChainId := eventLog.TargetChain.Int64()
+	sourceChainId := chain.Uint64()
+	targetChainId := eventLog.TargetChain.Uint64()
 	transactionId := fmt.Sprintf("%s-%d", eventLog.Raw.TxHash, eventLog.Raw.Index)
 	token := eventLog.Token.String()
 
@@ -451,7 +451,7 @@ func (ew *Watcher) handleLockLog(eventLog *router.RouterLock, q qi.Queue) {
 	ew.logger.Debugf("[%s] - New Lock Event Log received.", eventLog.Raw.TxHash)
 
 	transactionId := fmt.Sprintf("%s-%d", eventLog.Raw.TxHash, eventLog.Raw.Index)
-	targetChainId := eventLog.TargetChain.Int64()
+	targetChainId := eventLog.TargetChain.Uint64()
 	token := eventLog.Token.String()
 
 	if eventLog.Raw.Removed {
@@ -465,7 +465,7 @@ func (ew *Watcher) handleLockLog(eventLog *router.RouterLock, q qi.Queue) {
 	}
 	var chain *big.Int
 	chain, e := ew.evmClient.ChainID(context.Background())
-	sourceChainId := chain.Int64()
+	sourceChainId := chain.Uint64()
 	if e != nil {
 		ew.logger.Errorf("[%s] - Failed to retrieve chain ID.", eventLog.Raw.TxHash)
 		return
@@ -571,7 +571,7 @@ func (ew *Watcher) handleBurnERC721(eventLog *router.RouterBurnERC721, q qi.Queu
 		ew.logger.Errorf("[%s] - Failed to retrieve chain ID.", eventLog.Raw.TxHash)
 		return
 	}
-	nativeAsset := ew.mappings.WrappedToNative(eventLog.WrappedToken.String(), chain.Int64())
+	nativeAsset := ew.mappings.WrappedToNative(eventLog.WrappedToken.String(), chain.Uint64())
 	if nativeAsset == nil {
 		ew.logger.Errorf("[%s] - Failed to retrieve native asset of [%s].", eventLog.Raw.TxHash, eventLog.WrappedToken)
 		return
@@ -579,7 +579,7 @@ func (ew *Watcher) handleBurnERC721(eventLog *router.RouterBurnERC721, q qi.Queu
 
 	targetAsset := nativeAsset.Asset
 	// This is the case when you are bridging wrapped to wrapped
-	if eventLog.TargetChain.Int64() != nativeAsset.ChainId {
+	if eventLog.TargetChain.Uint64() != nativeAsset.ChainId {
 		ew.logger.Errorf("[%s] - Wrapped to Wrapped transfers currently not supported [%s] - [%d] for [%d]", eventLog.Raw.TxHash, nativeAsset.Asset, nativeAsset.ChainId, eventLog.TargetChain.Int64())
 		return
 	}
@@ -598,8 +598,8 @@ func (ew *Watcher) handleBurnERC721(eventLog *router.RouterBurnERC721, q qi.Queu
 
 	transfer := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", eventLog.Raw.TxHash, eventLog.Raw.Index),
-		SourceChainId: chain.Int64(),
-		TargetChainId: eventLog.TargetChain.Int64(),
+		SourceChainId: chain.Uint64(),
+		TargetChainId: eventLog.TargetChain.Uint64(),
 		NativeChainId: nativeAsset.ChainId,
 		SourceAsset:   eventLog.WrappedToken.String(),
 		TargetAsset:   targetAsset,
@@ -651,9 +651,9 @@ func (ew *Watcher) handleUnlockLog(eventLog *router.RouterUnlock) {
 	}
 
 	transactionId := string(eventLog.TransactionId)
-	sourceChainId := eventLog.SourceChain.Int64()
-	targetChainId := chain.Int64()
-	oppositeToken := ew.mappings.GetOppositeAsset(uint64(sourceChainId), uint64(targetChainId), eventLog.Token.String())
+	sourceChainId := eventLog.SourceChain.Uint64()
+	targetChainId := chain.Uint64()
+	oppositeToken := ew.mappings.GetOppositeAsset(sourceChainId, targetChainId, eventLog.Token.String())
 
 	metrics.SetUserGetHisTokens(sourceChainId, targetChainId, oppositeToken, transactionId, ew.prometheusService, ew.logger)
 }

--- a/app/process/watcher/evm/watcher_test.go
+++ b/app/process/watcher/evm/watcher_test.go
@@ -136,9 +136,9 @@ func Test_HandleLockLog_HappyPath(t *testing.T) {
 
 	parsedLockLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", lockLog.Raw.TxHash, lockLog.Raw.Index),
-		SourceChainId: int64(33),
-		TargetChainId: lockLog.TargetChain.Int64(),
-		NativeChainId: int64(33),
+		SourceChainId: 33,
+		TargetChainId: lockLog.TargetChain.Uint64(),
+		NativeChainId: 33,
 		SourceAsset:   lockLog.Token.String(),
 		TargetAsset:   constants.Hbar,
 		NativeAsset:   lockLog.Token.String(),
@@ -172,9 +172,9 @@ func Test_HandleLockLog_ReadOnlyHederaMintHtsTransfer(t *testing.T) {
 	mocks.MEVMClient.On("ChainID", context.Background()).Return(big.NewInt(33), nil)
 	parsedLockLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", lockLog.Raw.TxHash, lockLog.Raw.Index),
-		SourceChainId: int64(33),
-		TargetChainId: lockLog.TargetChain.Int64(),
-		NativeChainId: int64(33),
+		SourceChainId: 33,
+		TargetChainId: lockLog.TargetChain.Uint64(),
+		NativeChainId: 33,
 		SourceAsset:   lockLog.Token.String(),
 		TargetAsset:   constants.Hbar,
 		NativeAsset:   lockLog.Token.String(),
@@ -209,9 +209,9 @@ func Test_HandleLockLog_ReadOnlyTransferSave(t *testing.T) {
 	mocks.MEVMClient.On("ChainID", context.Background()).Return(big.NewInt(33), nil)
 	parsedLockLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", lockLog.Raw.TxHash, lockLog.Raw.Index),
-		SourceChainId: int64(33),
-		TargetChainId: lockLog.TargetChain.Int64(),
-		NativeChainId: int64(33),
+		SourceChainId: 33,
+		TargetChainId: lockLog.TargetChain.Uint64(),
+		NativeChainId: 33,
 		SourceAsset:   lockLog.Token.String(),
 		TargetAsset:   "0xsome-other-eth-address",
 		NativeAsset:   lockLog.Token.String(),
@@ -235,9 +235,9 @@ func Test_HandleLockLog_TopicMessageSubmission(t *testing.T) {
 	lockLog.TargetChain = big.NewInt(1)
 	parsedLockLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", lockLog.Raw.TxHash, lockLog.Raw.Index),
-		SourceChainId: int64(33),
-		TargetChainId: lockLog.TargetChain.Int64(),
-		NativeChainId: int64(33),
+		SourceChainId: 33,
+		TargetChainId: lockLog.TargetChain.Uint64(),
+		NativeChainId: 33,
 		SourceAsset:   lockLog.Token.String(),
 		TargetAsset:   "0xsome-other-eth-address",
 		NativeAsset:   lockLog.Token.String(),
@@ -260,9 +260,9 @@ func Test_HandleBurnLog_HappyPath(t *testing.T) {
 
 	parsedBurnLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", burnLog.Raw.TxHash, burnLog.Raw.Index),
-		SourceChainId: int64(33),
-		TargetChainId: burnLog.TargetChain.Int64(),
-		NativeChainId: int64(0),
+		SourceChainId: 33,
+		TargetChainId: burnLog.TargetChain.Uint64(),
+		NativeChainId: 0,
 		SourceAsset:   burnLog.Token.String(),
 		TargetAsset:   constants.Hbar,
 		NativeAsset:   constants.Hbar,
@@ -296,9 +296,9 @@ func Test_HandleBurnLog_TopicMessageSubmission(t *testing.T) {
 	receiver := common.BytesToAddress(burnLog.Receiver).String()
 	parsedBurnLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", burnLog.Raw.TxHash, burnLog.Raw.Index),
-		SourceChainId: int64(33),
+		SourceChainId: 33,
 		TargetChainId: 1,
-		NativeChainId: int64(1),
+		NativeChainId: 1,
 		SourceAsset:   burnLog.Token.String(),
 		TargetAsset:   "0xb083879B1e10C8476802016CB12cd2F25a896691",
 		NativeAsset:   "0xb083879B1e10C8476802016CB12cd2F25a896691",
@@ -339,9 +339,9 @@ func Test_HandleBurnLog_ReadOnlyTransferSave(t *testing.T) {
 	receiver := common.BytesToAddress(burnLog.Receiver).String()
 	parsedBurnLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", burnLog.Raw.TxHash, burnLog.Raw.Index),
-		SourceChainId: int64(33),
+		SourceChainId: 33,
 		TargetChainId: 1,
-		NativeChainId: int64(1),
+		NativeChainId: 1,
 		SourceAsset:   burnLog.Token.String(),
 		TargetAsset:   "0xb083879B1e10C8476802016CB12cd2F25a896691",
 		NativeAsset:   "0xb083879B1e10C8476802016CB12cd2F25a896691",
@@ -378,9 +378,9 @@ func Test_HandleBurnLog_ReadOnlyHederaTransfer(t *testing.T) {
 	mocks.MEVMClient.On("ChainID", context.Background()).Return(big.NewInt(33), nil)
 	parsedBurnLog := &transfer.Transfer{
 		TransactionId: fmt.Sprintf("%s-%d", burnLog.Raw.TxHash, burnLog.Raw.Index),
-		SourceChainId: int64(33),
+		SourceChainId: 33,
 		TargetChainId: 0,
-		NativeChainId: int64(0),
+		NativeChainId: 0,
 		SourceAsset:   burnLog.Token.String(),
 		TargetAsset:   constants.Hbar,
 		NativeAsset:   constants.Hbar,

--- a/app/process/watcher/prometheus/watcher.go
+++ b/app/process/watcher/prometheus/watcher.go
@@ -39,7 +39,7 @@ import (
 type Watcher struct {
 	dashboardPolling          time.Duration
 	mirrorNode                client.MirrorNode
-	EVMClients                map[int64]client.EVM
+	EVMClients                map[uint64]client.EVM
 	configuration             config.Config
 	prometheusService         service.Prometheus
 	logger                    *log.Entry
@@ -47,7 +47,7 @@ type Watcher struct {
 	bridgeAccountBalanceGauge prometheus.Gauge
 	operatorBalanceGauge      prometheus.Gauge
 	// A mapping, storing all network ID - asset address - metric name
-	assetsMetrics map[int64]map[string]string
+	assetsMetrics map[uint64]map[string]string
 }
 
 func NewWatcher(
@@ -55,7 +55,7 @@ func NewWatcher(
 	mirrorNode client.MirrorNode,
 	configuration config.Config,
 	prometheusService service.Prometheus,
-	EVMClients map[int64]client.EVM,
+	EVMClients map[uint64]client.EVM,
 ) *Watcher {
 
 	var (
@@ -63,7 +63,7 @@ func NewWatcher(
 		bridgeAccountBalanceGauge prometheus.Gauge
 		operatorBalanceGauge      prometheus.Gauge
 		// A mapping, storing all network ID - asset address - metric name
-		assetsMetrics = make(map[int64]map[string]string)
+		assetsMetrics = make(map[uint64]map[string]string)
 	)
 
 	if prometheusService.GetIsMonitoringEnabled() {
@@ -142,8 +142,8 @@ func (pw Watcher) registerAssetsMetrics() {
 }
 
 func (pw Watcher) registerAssetMetric(
-	nativeNetworkId int64,
-	wrappedNetworkId int64,
+	nativeNetworkId,
+	wrappedNetworkId uint64,
 	assetAddress string,
 	metricNameCnt string,
 	metricHelpCnt string,
@@ -175,7 +175,7 @@ func (pw Watcher) registerAssetMetric(
 	}
 }
 
-func (pw Watcher) getAssetData(networkId int64, assetAddress string) (name string, symbol string, err error) {
+func (pw Watcher) getAssetData(networkId uint64, assetAddress string) (name string, symbol string, err error) {
 	if networkId == constants.HederaNetworkId { // Hedera
 		asset, e := pw.mirrorNode.GetToken(assetAddress)
 		if e != nil {
@@ -208,16 +208,16 @@ func (pw Watcher) getAssetData(networkId int64, assetAddress string) (name strin
 }
 
 func getMetricData(
-	nativeNetworkId int64,
-	wrappedNetworkId int64,
+	nativeNetworkId,
+	wrappedNetworkId uint64,
 	assetAddress string,
 	assetName string,
 	metricNameSuffix string,
 	metricsHelpPrefix string,
 ) (string, string) {
 
-	nativeNetworkName := constants.NetworksById[uint64(nativeNetworkId)]
-	wrappedNetworkName := constants.NetworksById[uint64(wrappedNetworkId)]
+	nativeNetworkName := constants.NetworksById[nativeNetworkId]
+	wrappedNetworkName := constants.NetworksById[wrappedNetworkId]
 	assetType := constants.Wrapped
 	if nativeNetworkId == wrappedNetworkId {
 		assetType = constants.Native
@@ -291,7 +291,7 @@ func (pw Watcher) setAssetsMetrics(bridgeAccount *model.AccountsResponse) {
 	}
 }
 
-func (pw Watcher) prepareAndSetAssetMetric(networkId int64,
+func (pw Watcher) prepareAndSetAssetMetric(networkId uint64,
 	assetAddress string,
 	bridgeAccount *model.AccountsResponse,
 	isNative bool,
@@ -318,7 +318,7 @@ func (pw Watcher) prepareAndSetAssetMetric(networkId int64,
 }
 
 func (pw Watcher) getAssetMetricValue(
-	networkId int64,
+	networkId uint64,
 	assetAddress string,
 	bridgeAccount *model.AccountsResponse,
 	isNative bool,
@@ -416,7 +416,7 @@ func (pw Watcher) getHederaTokenSupply(assetAddress string) (float64, error) {
 }
 
 func (pw Watcher) getEVMBalance(
-	networkId int64,
+	networkId uint64,
 	evmAssetInstance *wtoken.Wtoken,
 	decimal uint8,
 	assetAddress string,
@@ -438,7 +438,7 @@ func (pw Watcher) getEVMBalance(
 
 func (pw Watcher) getEVMSupply(evmAssetInstance *wtoken.Wtoken,
 	decimal uint8,
-	networkId int64,
+	networkId uint64,
 	assetAddress string,
 ) (float64, error) {
 	ts, e := evmAssetInstance.TotalSupply(&bind.CallOpts{})

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -46,7 +46,7 @@ type Watcher struct {
 	statusRepository  repository.Status
 	targetTimestamp   int64
 	logger            *log.Entry
-	contractServices  map[int64]service.Contracts
+	contractServices  map[uint64]service.Contracts
 	mappings          config.Assets
 	hederaNftFees     map[string]int64
 	validator         bool
@@ -60,7 +60,7 @@ func NewWatcher(
 	pollingInterval time.Duration,
 	repository repository.Status,
 	startTimestamp int64,
-	contractServices map[int64]service.Contracts,
+	contractServices map[uint64]service.Contracts,
 	mappings config.Assets,
 	hederaNftFees map[string]int64,
 	validator bool,
@@ -264,7 +264,7 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 	q.Push(&queue.Message{Payload: transferMessage, Topic: topic})
 }
 
-func (ctw Watcher) createFungiblePayload(transactionID string, receiver string, sourceAsset string, asset config.NativeAsset, amount int64, targetChainId int64, targetChainAsset string) (*transfer.Transfer, error) {
+func (ctw Watcher) createFungiblePayload(transactionID string, receiver string, sourceAsset string, asset config.NativeAsset, amount int64, targetChainId uint64, targetChainAsset string) (*transfer.Transfer, error) {
 	nativeAsset := ctw.mappings.FungibleNativeAsset(asset.ChainId, asset.Asset)
 	properAmount, err := ctw.contractServices[targetChainId].AddDecimals(big.NewInt(amount), targetChainAsset)
 	if err != nil {
@@ -298,7 +298,7 @@ func (ctw Watcher) createNonFungiblePayload(
 	sourceAsset string,
 	nativeAsset config.NativeAsset,
 	serialNum int64,
-	targetChainId int64,
+	targetChainId uint64,
 	targetChainAsset string) (*transfer.Transfer, error) {
 	nftData, err := ctw.client.GetNft(sourceAsset, serialNum)
 	if err != nil {
@@ -322,7 +322,7 @@ func (ctw Watcher) createNonFungiblePayload(
 		string(decodedMetadata)), nil
 }
 
-func (ctw Watcher) initSuccessRatePrometheusMetrics(tx model.Transaction, sourceChainId, targetChainId int64, asset string) {
+func (ctw Watcher) initSuccessRatePrometheusMetrics(tx model.Transaction, sourceChainId, targetChainId uint64, asset string) {
 	if !ctw.prometheusService.GetIsMonitoringEnabled() {
 		return
 	}

--- a/app/process/watcher/transfer/watcher_test.go
+++ b/app/process/watcher/transfer/watcher_test.go
@@ -43,12 +43,12 @@ var (
 		},
 		ConsensusTimestamp: "1631092491.483966000",
 	}
-	networks = map[int64]*parser.Network{
+	networks = map[uint64]*parser.Network{
 		0: {
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					"0.0.111111": {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							3: "0x0000000000000000000000000000000000000001",
 						},
 					},
@@ -62,7 +62,7 @@ var (
 func Test_NewMemo_MissingWrappedCorrelation(t *testing.T) {
 	w := initializeWatcher()
 	mocks.MHederaMirrorClient.On("GetSuccessfulTransaction", tx.TransactionID).Return(tx, nil)
-	mocks.MTransferService.On("SanityCheckTransfer", mock.Anything).Return(int64(0), "0xevmaddress", nil)
+	mocks.MTransferService.On("SanityCheckTransfer", mock.Anything).Return(uint64(0), "0xevmaddress", nil)
 
 	w.processTransaction(tx.TransactionID, mocks.MQueue)
 	mocks.MTransferService.AssertCalled(t, "SanityCheckTransfer", tx)
@@ -81,7 +81,7 @@ func Test_NewWatcher_RecordNotFound_Creates(t *testing.T) {
 		5,
 		mocks.MStatusRepository,
 		0,
-		map[int64]iservice.Contracts{3: mocks.MBridgeContractService, 0: mocks.MBridgeContractService},
+		map[uint64]iservice.Contracts{3: mocks.MBridgeContractService, 0: mocks.MBridgeContractService},
 		assets,
 		map[string]int64{},
 		true,
@@ -101,7 +101,7 @@ func Test_NewWatcher_NotNilTS_Works(t *testing.T) {
 		5,
 		mocks.MStatusRepository,
 		1,
-		map[int64]iservice.Contracts{3: mocks.MBridgeContractService, 0: mocks.MBridgeContractService},
+		map[uint64]iservice.Contracts{3: mocks.MBridgeContractService, 0: mocks.MBridgeContractService},
 		assets,
 		map[string]int64{},
 		true,
@@ -124,7 +124,7 @@ func Test_Watch_AccountNotExist(t *testing.T) {
 func Test_ProcessTransaction(t *testing.T) {
 	w := initializeWatcher()
 	mocks.MHederaMirrorClient.On("GetSuccessfulTransaction", tx.TransactionID).Return(tx, nil)
-	mocks.MTransferService.On("SanityCheckTransfer", tx).Return(int64(3), "0xaiskdjakdjakl", nil)
+	mocks.MTransferService.On("SanityCheckTransfer", tx).Return(uint64(3), "0xaiskdjakdjakl", nil)
 	mocks.MQueue.On("Push", mock.Anything).Return()
 	mocks.MBridgeContractService.On("AddDecimals", big.NewInt(10), "0x0000000000000000000000000000000000000001").Return(big.NewInt(10), nil)
 	w.processTransaction(tx.TransactionID, mocks.MQueue)
@@ -135,7 +135,7 @@ func Test_ProcessTransaction_WithTS(t *testing.T) {
 	anotherTx := tx
 	anotherTx.ConsensusTimestamp = fmt.Sprintf("%d.0", time.Now().Add(time.Hour).Unix())
 	mocks.MHederaMirrorClient.On("GetSuccessfulTransaction", anotherTx.TransactionID).Return(anotherTx, nil)
-	mocks.MTransferService.On("SanityCheckTransfer", anotherTx).Return(int64(3), "0xaiskdjakdjakl", nil)
+	mocks.MTransferService.On("SanityCheckTransfer", anotherTx).Return(uint64(3), "0xaiskdjakdjakl", nil)
 	mocks.MBridgeContractService.On("AddDecimals", big.NewInt(10), "0x0000000000000000000000000000000000000001").Return(big.NewInt(10), nil)
 	mocks.MQueue.On("Push", mock.Anything).Return()
 	w.processTransaction(anotherTx.TransactionID, mocks.MQueue)
@@ -150,7 +150,7 @@ func Test_UpdateStatusTimestamp_Works(t *testing.T) {
 func Test_ProcessTransaction_SanityCheckTransfer_Fails(t *testing.T) {
 	w := initializeWatcher()
 	mocks.MHederaMirrorClient.On("GetSuccessfulTransaction", tx.TransactionID).Return(tx, nil)
-	mocks.MTransferService.On("SanityCheckTransfer", tx).Return(int64(0), "", errors.New("some-error"))
+	mocks.MTransferService.On("SanityCheckTransfer", tx).Return(uint64(0), "", errors.New("some-error"))
 
 	w.processTransaction(tx.TransactionID, mocks.MQueue)
 
@@ -174,7 +174,7 @@ func Test_ConsensusTimestamp_Fails(t *testing.T) {
 	anotherTx := tx
 	anotherTx.ConsensusTimestamp = "asd"
 	mocks.MHederaMirrorClient.On("GetSuccessfulTransaction", anotherTx.TransactionID).Return(anotherTx, nil)
-	mocks.MTransferService.On("SanityCheckTransfer", anotherTx).Return(int64(3), "0xaiskdjakdjakl", nil)
+	mocks.MTransferService.On("SanityCheckTransfer", anotherTx).Return(uint64(3), "0xaiskdjakdjakl", nil)
 	mocks.MBridgeContractService.On("AddDecimals", big.NewInt(10), "0x0000000000000000000000000000000000000001").Return(big.NewInt(10), nil)
 	mocks.MQueue.On("Push", mock.Anything).Return()
 	w.processTransaction(anotherTx.TransactionID, mocks.MQueue)
@@ -197,7 +197,7 @@ func initializeWatcher() *Watcher {
 		5,
 		mocks.MStatusRepository,
 		0,
-		map[int64]iservice.Contracts{3: mocks.MBridgeContractService, 0: mocks.MBridgeContractService},
+		map[uint64]iservice.Contracts{3: mocks.MBridgeContractService, 0: mocks.MBridgeContractService},
 		assets,
 		map[string]int64{},
 		true,

--- a/app/services/burn-event/service.go
+++ b/app/services/burn-event/service.go
@@ -170,7 +170,7 @@ func (s Service) startAwaitingFunctionsForMetrics(event transfer.Transfer, feeOu
 	)
 }
 
-func (s Service) initSuccessRatePrometheusMetrics(transactionId string, sourceChainId, targetChainId int64, asset string) {
+func (s Service) initSuccessRatePrometheusMetrics(transactionId string, sourceChainId, targetChainId uint64, asset string) {
 	if !s.prometheusService.GetIsMonitoringEnabled() {
 		return
 	}
@@ -183,7 +183,7 @@ func (s Service) initSuccessRatePrometheusMetrics(transactionId string, sourceCh
 	}
 }
 
-func (s *Service) onMinedFeeTransactionsSetMetrics(sourceChainId int64, targetChainId int64, nativeAsset string, transactionId string, isTransferSuccessful bool) {
+func (s *Service) onMinedFeeTransactionsSetMetrics(sourceChainId, targetChainId uint64, nativeAsset string, transactionId string, isTransferSuccessful bool) {
 
 	if !s.prometheusService.GetIsMonitoringEnabled() || targetChainId != constants.HederaNetworkId || !isTransferSuccessful {
 		return
@@ -192,7 +192,7 @@ func (s *Service) onMinedFeeTransactionsSetMetrics(sourceChainId int64, targetCh
 	metrics.SetFeeTransferred(sourceChainId, targetChainId, nativeAsset, transactionId, s.prometheusService, s.logger)
 }
 
-func (s *Service) onMinedUserTransactionSetMetrics(sourceChainId int64, targetChainId int64, nativeAsset string, transactionId string, isTransferSuccessful bool) {
+func (s *Service) onMinedUserTransactionSetMetrics(sourceChainId, targetChainId uint64, nativeAsset string, transactionId string, isTransferSuccessful bool) {
 
 	if !s.prometheusService.GetIsMonitoringEnabled() || sourceChainId == constants.HederaNetworkId || !isTransferSuccessful {
 		return

--- a/app/services/lock-event/service.go
+++ b/app/services/lock-event/service.go
@@ -146,7 +146,7 @@ statusBlocker:
 	)
 }
 
-func (s Service) initSuccessRatePrometheusMetrics(transactionId string, sourceChainId, targetChainId int64, asset string) {
+func (s Service) initSuccessRatePrometheusMetrics(transactionId string, sourceChainId, targetChainId uint64, asset string) {
 	if !s.prometheusService.GetIsMonitoringEnabled() {
 		return
 	}

--- a/app/services/prometheus/service.go
+++ b/app/services/prometheus/service.go
@@ -73,14 +73,14 @@ func (s *Service) CreateGaugeIfNotExists(opts prometheus.GaugeOpts) prometheus.G
 	return gauge
 }
 
-func (s *Service) CreateSuccessRateGaugeIfNotExists(transactionId string, sourceChainId int64, targetChainId int64, asset, metricType, metricHelp string) (prometheus.Gauge, error) {
+func (s *Service) CreateSuccessRateGaugeIfNotExists(transactionId string, sourceChainId, targetChainId uint64, asset, metricType, metricHelp string) (prometheus.Gauge, error) {
 	if !s.isMonitoringEnabled {
 		return nil, errors.New("monitoring is disabled.")
 	}
 
 	metricName, err := s.ConstructMetricName(
-		uint64(sourceChainId),
-		uint64(targetChainId),
+		sourceChainId,
+		targetChainId,
 		asset,
 		transactionId,
 		metricType,
@@ -94,8 +94,8 @@ func (s *Service) CreateSuccessRateGaugeIfNotExists(transactionId string, source
 		Name: metricName,
 		Help: metricHelp,
 		ConstLabels: prometheus.Labels{
-			"source_network_id": strconv.FormatInt(sourceChainId, 10),
-			"target_network_id": strconv.FormatInt(targetChainId, 10),
+			"source_network_id": strconv.FormatUint(sourceChainId, 10),
+			"target_network_id": strconv.FormatUint(targetChainId, 10),
 			"asset":             asset,
 			"transaction_id":    transactionId,
 			"metric_type":       metricType,
@@ -156,7 +156,7 @@ func (s *Service) CreateCounterIfNotExists(opts prometheus.CounterOpts) promethe
 
 func (s *Service) ConstructMetricName(sourceNetworkId, targetNetworkId uint64, asset, transactionId, metricType string) (string, error) {
 	tokenType := constants.Wrapped
-	isNativeAsset := s.assetsConfig.IsNative(int64(sourceNetworkId), asset)
+	isNativeAsset := s.assetsConfig.IsNative(sourceNetworkId, asset)
 	if isNativeAsset {
 		tokenType = constants.Native
 	}

--- a/app/services/prometheus/service_test.go
+++ b/app/services/prometheus/service_test.go
@@ -89,8 +89,8 @@ func Test_CreateSuccessRateGaugeIfNotExists(t *testing.T) {
 	setup()
 
 	transactionId := "0.0.1234"
-	sourceChainId := int64(constants.HederaNetworkId)
-	targetChainId := int64(constants.NetworksByName["Ethereum"])
+	sourceChainId := constants.HederaNetworkId
+	targetChainId := constants.NetworksByName["Ethereum"]
 	asset := constants.Hbar
 	gauge, err := service.CreateSuccessRateGaugeIfNotExists(
 		transactionId,

--- a/cmd/clients.go
+++ b/cmd/clients.go
@@ -28,12 +28,12 @@ import (
 type Clients struct {
 	HederaNode client.HederaNode
 	MirrorNode client.MirrorNode
-	EVMClients map[int64]client.EVM
+	EVMClients map[uint64]client.EVM
 }
 
 // PrepareClients instantiates all the necessary clients for a validator node
 func PrepareClients(config config.Clients) *Clients {
-	EVMClients := make(map[int64]client.EVM)
+	EVMClients := make(map[uint64]client.EVM)
 	for chainId, ec := range config.Evm {
 		EVMClients[chainId] = evm.NewClient(ec)
 	}

--- a/cmd/clients_test.go
+++ b/cmd/clients_test.go
@@ -29,7 +29,7 @@ func TestPrepareClients(t *testing.T) {
 	clients := PrepareClients(tc.TestConfig.Node.Clients)
 	assert.NotEmpty(t, clients)
 
-	assert.IsType(t, map[int64]client.EVM{}, clients.EVMClients)
+	assert.IsType(t, map[uint64]client.EVM{}, clients.EVMClients)
 	assert.IsType(t, &hedera.Node{}, clients.HederaNode)
 	assert.IsType(t, &mirror_node.Client{}, clients.MirrorNode)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,7 @@ func initializeMonitoring(
 	s *server.Server,
 	configuration config.Config,
 	mirrorNode client.MirrorNode,
-	EVMClients map[int64]client.EVM,
+	EVMClients map[uint64]client.EVM,
 ) {
 	if configuration.Node.Monitoring.Enable {
 		initializePrometheusWatcher(s, configuration, mirrorNode, prometheusService, EVMClients)
@@ -108,6 +108,7 @@ func initializeAPIRouter(services *Services, bridgeConfig parser.Bridge) *apirou
 	apiRouter.AddV1Router(burn_event.Route, burn_event.NewRouter(services.burnEvents))
 	apiRouter.AddV1Router("/metrics", promhttp.Handler())
 	apiRouter.AddV1Router(config_bridge.Route, config_bridge.NewRouter(bridgeConfig))
+
 	return apiRouter
 }
 
@@ -159,11 +160,11 @@ func initializeServerPairs(server *server.Server, services *Services, repositori
 		if err != nil {
 			panic(err)
 		}
-		contractService := services.contractServices[chain.Int64()]
+		contractService := services.contractServices[chain.Uint64()]
 		// Given that addresses between different
 		// EVM networks might be the same, a concatenation between
 		// <chain-id>-<contract-address> removes possible duplication.
-		dbIdentifier := fmt.Sprintf("%d-%s", chain.Int64(), contractService.Address().String())
+		dbIdentifier := fmt.Sprintf("%d-%s", chain.Uint64(), contractService.Address().String())
 
 		server.AddWatcher(
 			evm.NewWatcher(
@@ -173,10 +174,10 @@ func initializeServerPairs(server *server.Server, services *Services, repositori
 				evmClient,
 				configuration.Bridge.Assets,
 				dbIdentifier,
-				configuration.Node.Clients.Evm[chain.Int64()].StartBlock,
+				configuration.Node.Clients.Evm[chain.Uint64()].StartBlock,
 				configuration.Node.Validator,
-				configuration.Node.Clients.Evm[chain.Int64()].PollingInterval,
-				configuration.Node.Clients.Evm[chain.Int64()].MaxLogsBlocks,
+				configuration.Node.Clients.Evm[chain.Uint64()].PollingInterval,
+				configuration.Node.Clients.Evm[chain.Uint64()].MaxLogsBlocks,
 			))
 	}
 
@@ -251,7 +252,7 @@ func initializePrometheusWatcher(
 	configuration config.Config,
 	mirrorNode client.MirrorNode,
 	prometheusService service.Prometheus,
-	EVMClients map[int64]client.EVM,
+	EVMClients map[uint64]client.EVM,
 ) {
 	dashboardPolling := configuration.Node.Monitoring.DashboardPolling * time.Minute
 	log.Infoln("Dashboard Polling interval: ", dashboardPolling)
@@ -267,7 +268,7 @@ func addTransferWatcher(configuration *config.Config,
 	bridgeService service.Transfers,
 	mirrorNode client.MirrorNode,
 	repository *repository.Status,
-	contractServices map[int64]service.Contracts,
+	contractServices map[uint64]service.Contracts,
 	prometheusService service.Prometheus,
 ) *tw.Watcher {
 	account := configuration.Bridge.Hedera.BridgeAccount
@@ -306,7 +307,7 @@ func addPrometheusWatcher(
 	mirrorNode client.MirrorNode,
 	configuration config.Config,
 	prometheusService service.Prometheus,
-	EVMClients map[int64]client.EVM,
+	EVMClients map[uint64]client.EVM,
 ) *pw.Watcher {
 	log.Debugf("Added Prometheus Watcher for dashboard metrics")
 	return pw.NewWatcher(

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -34,8 +34,8 @@ import (
 )
 
 type Services struct {
-	signers          map[int64]service.Signer
-	contractServices map[int64]service.Contracts
+	signers          map[uint64]service.Signer
+	contractServices map[uint64]service.Contracts
 	transfers        service.Transfers
 	messages         service.Messages
 	burnEvents       service.BurnEvent
@@ -49,14 +49,14 @@ type Services struct {
 
 // PrepareServices instantiates all the necessary services with their required context and parameters
 func PrepareServices(c config.Config, clients Clients, repositories Repositories) *Services {
-	evmSigners := make(map[int64]service.Signer)
-	contractServices := make(map[int64]service.Contracts)
+	evmSigners := make(map[uint64]service.Signer)
+	contractServices := make(map[uint64]service.Contracts)
 	for _, client := range clients.EVMClients {
 		chain, err := client.ChainID(context.Background())
 		if err != nil {
 			panic(err)
 		}
-		chainId := chain.Int64()
+		chainId := chain.Uint64()
 		evmSigners[chainId] = evm.NewEVMSigner(client.GetPrivateKey())
 		contractServices[chainId] = contracts.NewService(client, c.Bridge.EVMs[chainId].RouterContractAddress, c.Bridge.Assets.FungibleNetworkAssets(chainId))
 	}
@@ -131,15 +131,15 @@ func PrepareServices(c config.Config, clients Clients, repositories Repositories
 // PrepareApiOnlyServices instantiates all the necessary services with their
 // required context and parameters for running the Validator node in API Only mode
 func PrepareApiOnlyServices(c config.Config, clients Clients) *Services {
-	contractServices := make(map[int64]service.Contracts)
+	contractServices := make(map[uint64]service.Contracts)
 	for _, client := range clients.EVMClients {
 		chain, err := client.ChainID(context.Background())
 		if err != nil {
 			panic(err)
 		}
-		chainId := chain.Int64()
+		chainId := chain.Uint64()
 		contractService := contracts.NewService(client, c.Bridge.EVMs[chainId].RouterContractAddress, c.Bridge.Assets.FungibleNetworkAssets(chainId))
-		contractServices[chain.Int64()] = contractService
+		contractServices[chainId] = contractService
 	}
 
 	return &Services{

--- a/config/assets.go
+++ b/config/assets.go
@@ -28,48 +28,48 @@ import (
 
 type Assets struct {
 	// A mapping, storing all networks' native tokens and their corresponding wrapped tokens
-	nativeToWrapped map[int64]map[string]map[int64]string
+	nativeToWrapped map[uint64]map[string]map[uint64]string
 	// A mapping, storing all networks' wrapped tokens and their corresponding native asset
-	wrappedToNative map[int64]map[string]*NativeAsset
+	wrappedToNative map[uint64]map[string]*NativeAsset
 	// A mapping, storing all fungible tokens per network
-	fungibleNetworkAssets map[int64][]string
+	fungibleNetworkAssets map[uint64][]string
 	// A mapping, storing all fungible native assets per network
-	fungibleNativeAssets map[int64]map[string]*NativeAsset
+	fungibleNativeAssets map[uint64]map[string]*NativeAsset
 }
 
 type NativeAsset struct {
 	MinAmount *big.Int
-	ChainId   int64
+	ChainId   uint64
 	Asset     string
 }
 
-func (a Assets) GetNativeToWrapped() map[int64]map[string]map[int64]string {
+func (a Assets) GetNativeToWrapped() map[uint64]map[string]map[uint64]string {
 	return a.nativeToWrapped
 }
 
-func (a Assets) NativeToWrapped(nativeAsset string, nativeChainId, targetChainId int64) string {
+func (a Assets) NativeToWrapped(nativeAsset string, nativeChainId, targetChainId uint64) string {
 	return a.nativeToWrapped[nativeChainId][nativeAsset][targetChainId]
 }
 
-func (a Assets) WrappedToNative(wrappedAsset string, wrappedChainId int64) *NativeAsset {
+func (a Assets) WrappedToNative(wrappedAsset string, wrappedChainId uint64) *NativeAsset {
 	return a.wrappedToNative[wrappedChainId][wrappedAsset]
 }
 
-func (a Assets) FungibleNetworkAssets(id int64) []string {
+func (a Assets) FungibleNetworkAssets(id uint64) []string {
 	return a.fungibleNetworkAssets[id]
 }
 
-func (a Assets) FungibleNativeAsset(id int64, asset string) *NativeAsset {
+func (a Assets) FungibleNativeAsset(id uint64, asset string) *NativeAsset {
 	return a.fungibleNativeAssets[id][asset]
 }
 
-func (a Assets) IsNative(networkId int64, asset string) bool {
+func (a Assets) IsNative(networkId uint64, asset string) bool {
 	_, isNative := a.nativeToWrapped[networkId][asset]
 	return isNative
 }
 
 func (a Assets) GetOppositeAsset(sourceChainId uint64, targetChainId uint64, asset string) string {
-	sourceChainIdCasted, targetChainIdCasted := int64(sourceChainId), int64(targetChainId)
+	sourceChainIdCasted, targetChainIdCasted := sourceChainId, targetChainId
 
 	nativeAssetForTargetChain := a.WrappedToNative(asset, sourceChainIdCasted)
 	if nativeAssetForTargetChain != nil {
@@ -89,17 +89,17 @@ func (a Assets) GetOppositeAsset(sourceChainId uint64, targetChainId uint64, ass
 
 }
 
-func LoadAssets(networks map[int64]*parser.Network) Assets {
-	nativeToWrapped := make(map[int64]map[string]map[int64]string)
-	wrappedToNative := make(map[int64]map[string]*NativeAsset)
-	fungibleNetworkAssets := make(map[int64][]string)
-	fungibleNativeAssets := make(map[int64]map[string]*NativeAsset)
+func LoadAssets(networks map[uint64]*parser.Network) Assets {
+	nativeToWrapped := make(map[uint64]map[string]map[uint64]string)
+	wrappedToNative := make(map[uint64]map[string]*NativeAsset)
+	fungibleNetworkAssets := make(map[uint64][]string)
+	fungibleNativeAssets := make(map[uint64]map[string]*NativeAsset)
 
 	re, _ := regexp.Compile(constants.EvmCompatibleAddressPattern)
 
 	for nativeChainId, network := range networks {
 		if nativeToWrapped[nativeChainId] == nil {
-			nativeToWrapped[nativeChainId] = make(map[string]map[int64]string)
+			nativeToWrapped[nativeChainId] = make(map[string]map[uint64]string)
 		}
 		if fungibleNativeAssets[nativeChainId] == nil {
 			fungibleNativeAssets[nativeChainId] = make(map[string]*NativeAsset)
@@ -111,7 +111,7 @@ func LoadAssets(networks map[int64]*parser.Network) Assets {
 			}
 
 			if nativeToWrapped[nativeChainId][nativeAsset] == nil {
-				nativeToWrapped[nativeChainId][nativeAsset] = make(map[int64]string)
+				nativeToWrapped[nativeChainId][nativeAsset] = make(map[uint64]string)
 			}
 
 			minAmount, err := parseAmount(nativeAssetMapping.MinAmount)
@@ -147,7 +147,7 @@ func LoadAssets(networks map[int64]*parser.Network) Assets {
 			}
 
 			if nativeToWrapped[nativeChainId][nativeAsset] == nil {
-				nativeToWrapped[nativeChainId][nativeAsset] = make(map[int64]string)
+				nativeToWrapped[nativeChainId][nativeAsset] = make(map[uint64]string)
 			}
 			for wrappedChainId, wrappedAsset := range nativeAssetMapping.Networks {
 				if isMatch := re.MatchString(wrappedAsset); isMatch {

--- a/config/bridge.go
+++ b/config/bridge.go
@@ -26,7 +26,7 @@ import (
 type Bridge struct {
 	TopicId string
 	Hedera  *BridgeHedera
-	EVMs    map[int64]BridgeEvm
+	EVMs    map[uint64]BridgeEvm
 	Assets  Assets
 }
 
@@ -43,12 +43,12 @@ type HederaToken struct {
 	Fee           int64
 	FeePercentage int64
 	MinAmount     string
-	Networks      map[int64]string
+	Networks      map[uint64]string
 }
 
 type Token struct {
 	MinAmount *big.Int
-	Networks  map[int64]string
+	Networks  map[uint64]string
 }
 
 type BridgeEvm struct {
@@ -60,12 +60,12 @@ func NewBridge(bridge parser.Bridge) Bridge {
 	config := Bridge{
 		TopicId: bridge.TopicId,
 		Hedera:  nil,
-		EVMs:    make(map[int64]BridgeEvm),
+		EVMs:    make(map[uint64]BridgeEvm),
 		Assets:  LoadAssets(bridge.Networks),
 	}
 	for key, value := range bridge.Networks {
-		constants.NetworksByName[value.Name] = uint64(key)
-		constants.NetworksById[uint64(key)] = value.Name
+		constants.NetworksByName[value.Name] = key
+		constants.NetworksById[key] = value.Name
 
 		if value.Name == "Hedera" {
 			config.Hedera = &BridgeHedera{

--- a/config/node.go
+++ b/config/node.go
@@ -41,7 +41,7 @@ type Database struct {
 }
 
 type Clients struct {
-	Evm        map[int64]Evm
+	Evm        map[uint64]Evm
 	Hedera     Hedera
 	MirrorNode MirrorNode
 }
@@ -103,7 +103,7 @@ func New(node parser.Node) Node {
 				Rpc:            rpc,
 			},
 			MirrorNode: MirrorNode(node.Clients.MirrorNode),
-			Evm:        make(map[int64]Evm),
+			Evm:        make(map[uint64]Evm),
 		},
 		LogLevel:  node.LogLevel,
 		Port:      node.Port,

--- a/config/parser/bridge.go
+++ b/config/parser/bridge.go
@@ -20,8 +20,8 @@ package parser
 	Structs used to parse the bridge YAML configuration
 */
 type Bridge struct {
-	TopicId  string             `yaml:"topic_id" json:"topicId,omitempty"`
-	Networks map[int64]*Network `yaml:"networks" json:"networks,omitempty"`
+	TopicId  string              `yaml:"topic_id" json:"topicId,omitempty"`
+	Networks map[uint64]*Network `yaml:"networks" json:"networks,omitempty"`
 }
 
 type Network struct {
@@ -39,8 +39,8 @@ type Tokens struct {
 }
 
 type Token struct {
-	Fee           int64            `yaml:"fee" json:"fee,omitempty"`                      // Represent a constant fee for Non-Fungible tokens. Applies only for Hedera Native Tokens
-	FeePercentage int64            `yaml:"fee_percentage" json:"feePercentage,omitempty"` // Represents a constant fee for Fungible Tokens. Applies only for Hedera Native Tokens
-	MinAmount     string           `yaml:"min_amount" json:"minAmount,omitempty"`         // Represents a constant minimum amount for each Native token.
-	Networks      map[int64]string `yaml:"networks" json:"networks,omitempty"`
+	Fee           int64             `yaml:"fee" json:"fee,omitempty"`                      // Represent a constant fee for Non-Fungible tokens. Applies only for Hedera Native Tokens
+	FeePercentage int64             `yaml:"fee_percentage" json:"feePercentage,omitempty"` // Represents a constant fee for Fungible Tokens. Applies only for Hedera Native Tokens
+	MinAmount     string            `yaml:"min_amount" json:"minAmount,omitempty"`         // Represents a constant minimum amount for each Native token.
+	Networks      map[uint64]string `yaml:"networks" json:"networks,omitempty"`
 }

--- a/config/parser/node.go
+++ b/config/parser/node.go
@@ -39,9 +39,9 @@ type Database struct {
 }
 
 type Clients struct {
-	Evm        map[int64]Evm `yaml:"evm"`
-	Hedera     Hedera        `yaml:"hedera"`
-	MirrorNode MirrorNode    `yaml:"mirror_node"`
+	Evm        map[uint64]Evm `yaml:"evm"`
+	Hedera     Hedera         `yaml:"hedera"`
+	MirrorNode MirrorNode     `yaml:"mirror_node"`
 }
 
 type Evm struct {

--- a/constants/hedera.go
+++ b/constants/hedera.go
@@ -18,7 +18,7 @@ package constants
 
 const (
 	Hbar            = "HBAR"
-	HederaNetworkId = 0
+	HederaNetworkId = uint64(0)
 )
 
 // Handler topics

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -72,7 +72,7 @@ func Test_HBAR(t *testing.T) {
 	setupEnv := setup.Load()
 	now = time.Now()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	receiver := evm.Receiver
 	memo := fmt.Sprintf("%d-%s", chainId, evm.Receiver.String())
@@ -148,7 +148,7 @@ func Test_E2E_Token_Transfer(t *testing.T) {
 	setupEnv := setup.Load()
 	now = time.Now()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	memo := fmt.Sprintf("%d-%s", chainId, evm.Receiver.String())
 	mintAmount, fee := calculateReceiverAndFeeAmounts(setupEnv, setupEnv.TokenID.String(), amount)
@@ -220,7 +220,7 @@ func Test_EVM_Hedera_HBAR(t *testing.T) {
 	amount := int64(100000000) // 1 HBAR
 	setupEnv := setup.Load()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	now = time.Now()
 	accountBalanceBefore := util.GetHederaAccountBalance(setupEnv.Clients.Hedera, setupEnv.Clients.Hedera.GetOperatorAccountID(), t)
@@ -277,7 +277,7 @@ func Test_EVM_Hedera_Token(t *testing.T) {
 	amount := int64(100000000) // 1 HBAR
 	setupEnv := setup.Load()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	now = time.Now()
 	accountBalanceBefore := util.GetHederaAccountBalance(setupEnv.Clients.Hedera, setupEnv.Clients.Hedera.GetOperatorAccountID(), t)
@@ -343,7 +343,7 @@ func Test_EVM_Hedera_Native_Token(t *testing.T) {
 	// Step 1: Initialize setup, smart contracts, etc.
 	setupEnv := setup.Load()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	now = time.Now()
 	bridgeAccountBalanceBefore := util.GetHederaAccountBalance(setupEnv.Clients.Hedera, setupEnv.BridgeAccount, t)
@@ -478,7 +478,7 @@ func Test_E2E_Hedera_EVM_Native_Token(t *testing.T) {
 	setupEnv := setup.Load()
 	now = time.Now()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	memo := fmt.Sprintf("%d-%s", chainId, evm.Receiver.String())
 	unlockAmount := int64(10) // Amount, which converted to 18 decimals is 100000000000 (100 gwei)
@@ -576,10 +576,10 @@ func Test_EVM_Native_to_EVM_Token(t *testing.T) {
 	// Step 1 - Initialize setup, smart contracts, etc.
 	setupEnv := setup.Load()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	now = time.Now()
-	targetChainID := int64(43113) // represents Avalanche Fuji Testnet (e2e config must have configuration for that particular network)
+	targetChainID := uint64(43113) // represents Avalanche Fuji Testnet (e2e config must have configuration for that particular network)
 	wrappedAsset, err := setup.NativeToWrappedAsset(setupEnv.AssetMappings, chainId, targetChainID, setupEnv.NativeEvmToken)
 	if err != nil {
 		t.Fatal(err)
@@ -654,8 +654,8 @@ func Test_EVM_Wrapped_to_EVM_Token(t *testing.T) {
 	// Step 1 - Initialize setup, smart contracts, etc.
 	setupEnv := setup.Load()
 
-	chainId := int64(80001)     // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
-	sourceChain := int64(43113) // represents Avalanche Fuji Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001)     // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	sourceChain := uint64(43113) // represents Avalanche Fuji Testnet (e2e config must have configuration for that particular network)
 	wrappedEvm := setupEnv.Clients.EVM[sourceChain]
 	now = time.Now()
 	sourceAsset, err := setup.NativeToWrappedAsset(setupEnv.AssetMappings, chainId, sourceChain, setupEnv.NativeEvmToken)
@@ -733,7 +733,7 @@ func Test_Hedera_Native_EVM_NFT_Transfer(t *testing.T) {
 	setupEnv := setup.Load()
 	nftToken := setupEnv.NftTokenID.String()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 	receiver := evm.Receiver
 	memo := fmt.Sprintf("%d-%s", chainId, evm.Receiver.String())
@@ -849,7 +849,7 @@ func Test_Hedera_EVM_BurnERC721_Transfer(t *testing.T) {
 	setupEnv := setup.Load()
 	nftToken := setupEnv.NftTokenID.String()
 
-	chainId := int64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
+	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
 
 	wrappedAsset, err := setup.NativeToWrappedAsset(setupEnv.AssetMappings, 0, chainId, nftToken)
@@ -1364,7 +1364,7 @@ func submitMintTransaction(evm setup.EVMUtils, txId string, transactionData *ser
 
 	res, err := evm.RouterContract.Mint(
 		evm.KeyTransactor,
-		big.NewInt(transactionData.SourceChainId),
+		new(big.Int).SetUint64(transactionData.SourceChainId),
 		[]byte(txId),
 		tokenAddress,
 		evm.Receiver,
@@ -1390,7 +1390,7 @@ func submitMintERC721Transaction(evm setup.EVMUtils, txId string, transactionDat
 
 	res, err := evm.RouterContract.MintERC721(
 		evm.KeyTransactor,
-		big.NewInt(transactionData.SourceChainId),
+		new(big.Int).SetUint64(transactionData.SourceChainId),
 		[]byte(txId),
 		common.HexToAddress(transactionData.TargetAsset),
 		big.NewInt(transactionData.TokenId),
@@ -1421,7 +1421,7 @@ func submitUnlockTransaction(evm setup.EVMUtils, txId string, transactionData *s
 
 	res, err := evm.RouterContract.Unlock(
 		evm.KeyTransactor,
-		big.NewInt(transactionData.SourceChainId),
+		new(big.Int).SetUint64(transactionData.SourceChainId),
 		[]byte(txId),
 		tokenAddress,
 		mintAmount,
@@ -1507,7 +1507,7 @@ func generateMirrorNodeExpectedTransfersForHederaTransfer(setupEnv *setup.Setup,
 	return expectedTransfers
 }
 
-func sendBurnEthTransaction(assetMappings config.Assets, evm setup.EVMUtils, asset string, sourceChainId, targetChainId int64, receiver []byte, amount int64, t *testing.T) (*types.Receipt, *router.RouterBurn) {
+func sendBurnEthTransaction(assetMappings config.Assets, evm setup.EVMUtils, asset string, sourceChainId, targetChainId uint64, receiver []byte, amount int64, t *testing.T) (*types.Receipt, *router.RouterBurn) {
 	wrappedAsset, err := setup.NativeToWrappedAsset(assetMappings, sourceChainId, targetChainId, asset)
 	if err != nil {
 		t.Fatal(err)
@@ -1529,7 +1529,7 @@ func sendBurnEthTransaction(assetMappings config.Assets, evm setup.EVMUtils, ass
 	fmt.Println(fmt.Sprintf("[%s] Waiting for Approval Transaction", approveTx.Hash()))
 	waitForTransaction(evm, approveTx.Hash(), t)
 
-	burnTx, err := evm.RouterContract.Burn(evm.KeyTransactor, big.NewInt(sourceChainId), common.HexToAddress(wrappedAsset), approvedValue, receiver)
+	burnTx, err := evm.RouterContract.Burn(evm.KeyTransactor, new(big.Int).SetUint64(sourceChainId), common.HexToAddress(wrappedAsset), approvedValue, receiver)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1554,7 +1554,7 @@ func sendBurnEthTransaction(assetMappings config.Assets, evm setup.EVMUtils, ass
 	return burnTxReceipt, expectedRouterBurn
 }
 
-func sendLockEthTransaction(evm setup.EVMUtils, asset string, targetChainId int64, receiver []byte, amount int64, t *testing.T) (*types.Receipt, *router.RouterLock) {
+func sendLockEthTransaction(evm setup.EVMUtils, asset string, targetChainId uint64, receiver []byte, amount int64, t *testing.T) (*types.Receipt, *router.RouterLock) {
 	approvedValue := big.NewInt(amount)
 
 	instance, err := setup.InitAssetContract(asset, evm.EVMClient)
@@ -1582,14 +1582,14 @@ func sendLockEthTransaction(evm setup.EVMUtils, asset string, targetChainId int6
 	fmt.Println(fmt.Sprintf("[%s] Waiting for Approval Transaction", approveTx.Hash()))
 	waitForTransaction(evm, approveTx.Hash(), t)
 
-	lockTx, err := evm.RouterContract.Lock(evm.KeyTransactor, big.NewInt(targetChainId), common.HexToAddress(asset), approvedValue, receiver)
+	lockTx, err := evm.RouterContract.Lock(evm.KeyTransactor, new(big.Int).SetUint64(targetChainId), common.HexToAddress(asset), approvedValue, receiver)
 	if err != nil {
 		t.Fatal(err)
 	}
 	fmt.Println(fmt.Sprintf("[%s] Submitted Lock Transaction", lockTx.Hash()))
 
 	expectedRouterLock := &router.RouterLock{
-		TargetChain: big.NewInt(targetChainId),
+		TargetChain: new(big.Int).SetUint64(targetChainId),
 		Token:       common.HexToAddress(asset),
 		Receiver:    receiver,
 		Amount:      approvedValue,

--- a/e2e/setup/config.go
+++ b/e2e/setup/config.go
@@ -61,7 +61,7 @@ func Load() *Setup {
 			MirrorNode:        config.MirrorNode(e2eConfig.Hedera.MirrorNode),
 			Monitoring:        config.Monitoring(e2eConfig.Hedera.Monitoring),
 		},
-		EVM:            make(map[int64]config.Evm),
+		EVM:            make(map[uint64]config.Evm),
 		Tokens:         e2eConfig.Tokens,
 		ValidatorUrl:   e2eConfig.ValidatorUrl,
 		Bridge:         e2eConfig.Bridge,
@@ -170,7 +170,7 @@ func newSetup(config Config) (*Setup, error) {
 // clients used by the e2e tests
 type clients struct {
 	Hedera          *hederaSDK.Client
-	EVM             map[int64]EVMUtils
+	EVM             map[uint64]EVMUtils
 	MirrorNode      *mirror_node.Client
 	ValidatorClient *e2eClients.Validator
 	FeeCalculator   service.Fee
@@ -184,7 +184,7 @@ func newClients(config Config) (*clients, error) {
 		return nil, err
 	}
 
-	EVM := make(map[int64]EVMUtils)
+	EVM := make(map[uint64]EVMUtils)
 	for chainId, conf := range config.EVM {
 		evmClient := evm.NewClient(conf)
 		routerContractAddress := common.HexToAddress(config.Bridge.Networks[chainId].RouterContractAddress)
@@ -222,7 +222,7 @@ func newClients(config Config) (*clients, error) {
 	}, nil
 }
 
-func InitWrappedAssetContract(nativeAsset string, nativeAssets config.Assets, sourceChain, targetChain int64, evmClient *evm.Client) (*wtoken.Wtoken, error) {
+func InitWrappedAssetContract(nativeAsset string, nativeAssets config.Assets, sourceChain, targetChain uint64, evmClient *evm.Client) (*wtoken.Wtoken, error) {
 	wTokenContractAddress, err := NativeToWrappedAsset(nativeAssets, sourceChain, targetChain, nativeAsset)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func InitAssetContract(asset string, evmClient *evm.Client) (*wtoken.Wtoken, err
 	return wtoken.NewWtoken(common.HexToAddress(asset), evmClient.GetClient())
 }
 
-func NativeToWrappedAsset(assetMappings config.Assets, sourceChain, targetChain int64, nativeAsset string) (string, error) {
+func NativeToWrappedAsset(assetMappings config.Assets, sourceChain, targetChain uint64, nativeAsset string) (string, error) {
 	wrappedAsset := assetMappings.NativeToWrapped(nativeAsset, sourceChain, targetChain)
 
 	if wrappedAsset == "" {
@@ -245,7 +245,7 @@ func NativeToWrappedAsset(assetMappings config.Assets, sourceChain, targetChain 
 	return wrappedAsset, nil
 }
 
-func WrappedToNativeAsset(assetMappings config.Assets, sourceChainId int64, asset string) (*config.NativeAsset, error) {
+func WrappedToNativeAsset(assetMappings config.Assets, sourceChainId uint64, asset string) (*config.NativeAsset, error) {
 	targetAsset := assetMappings.WrappedToNative(asset, sourceChainId)
 	if targetAsset == nil {
 		return nil, errors.New(fmt.Sprintf("Wrapped token [%s] on [%d] is not supported", asset, sourceChainId))
@@ -282,7 +282,7 @@ func initHederaClient(sender Sender, networkType string) (*hederaSDK.Client, err
 // Config used to load and parse from application.yml
 type Config struct {
 	Hedera         Hedera
-	EVM            map[int64]config.Evm
+	EVM            map[uint64]config.Evm
 	Tokens         e2eParser.Tokens
 	ValidatorUrl   string
 	Bridge         parser.Bridge

--- a/e2e/setup/parser/parser.go
+++ b/e2e/setup/parser/parser.go
@@ -6,11 +6,11 @@ import (
 
 // Config used to load and parse from application.yml
 type Config struct {
-	Hedera       HederaParser         `yaml:"hedera"`
-	EVM          map[int64]parser.Evm `yaml:"evm"`
-	Tokens       Tokens               `yaml:"tokens"`
-	ValidatorUrl string               `yaml:"validator_url"`
-	Bridge       parser.Bridge        `yaml:"bridge"`
+	Hedera       HederaParser          `yaml:"hedera"`
+	EVM          map[uint64]parser.Evm `yaml:"evm"`
+	Tokens       Tokens                `yaml:"tokens"`
+	ValidatorUrl string                `yaml:"validator_url"`
+	Bridge       parser.Bridge         `yaml:"bridge"`
 }
 
 type HederaParser struct {
@@ -37,9 +37,9 @@ type Tokens struct {
 }
 
 type E2E struct {
-	Hedera       HederaParser         `yaml:"hedera"`
-	EVM          map[int64]parser.Evm `yaml:"evm"`
-	Tokens       Tokens               `yaml:"tokens"`
-	ValidatorUrl string               `yaml:"validator_url"`
+	Hedera       HederaParser          `yaml:"hedera"`
+	EVM          map[uint64]parser.Evm `yaml:"evm"`
+	Tokens       Tokens                `yaml:"tokens"`
+	ValidatorUrl string                `yaml:"validator_url"`
 	Bridge       parser.Bridge
 }

--- a/e2e/util/expectation.go
+++ b/e2e/util/expectation.go
@@ -44,7 +44,7 @@ func PrepareExpectedFeeRecord(transactionID, scheduleID string, amount int64, tr
 func PrepareExpectedTransfer(
 	sourceChainId,
 	targetChainId,
-	nativeChainId int64,
+	nativeChainId uint64,
 	transactionID,
 	sourceAsset,
 	targetAsset,

--- a/test/constants/assets.go
+++ b/test/constants/assets.go
@@ -22,13 +22,13 @@ import (
 )
 
 var (
-	Networks = map[int64]*parser.Network{
+	Networks = map[uint64]*parser.Network{
 		0: {
 			Name: "Hedera",
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					constants.Hbar: {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							33: "0x0000000000000000000000000000000000000001",
 						},
 					},
@@ -41,7 +41,7 @@ var (
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					"0xb083879B1e10C8476802016CB12cd2F25a896691": {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							33: "0x0000000000000000000000000000000000000123",
 						},
 					},
@@ -54,7 +54,7 @@ var (
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					"0x0000000000000000000000000000000000000000": {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							0: "",
 						},
 					},
@@ -67,7 +67,7 @@ var (
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					"0x0000000000000000000000000000000000000000": {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							0: "",
 						},
 					},
@@ -80,7 +80,7 @@ var (
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					"0x0000000000000000000000000000000000000000": {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							0: "",
 						},
 					},
@@ -93,7 +93,7 @@ var (
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					"0x0000000000000000000000000000000000000000": {
-						Networks: map[int64]string{
+						Networks: map[uint64]string{
 							0: constants.Hbar,
 							1: "0xsome-other-eth-address",
 						},

--- a/test/mocks/service/message_service_mock.go
+++ b/test/mocks/service/message_service_mock.go
@@ -63,7 +63,7 @@ func (m *MockMessageService) SanityCheckNftSignature(tm *proto.TopicEthNftSignat
 }
 
 // ProcessSignature processes the signature message, verifying and updating all necessary fields in the DB
-func (m *MockMessageService) ProcessSignature(transferID, signature string, targetChainId, timestamp int64, authMsg []byte) error {
+func (m *MockMessageService) ProcessSignature(transferID, signature string, targetChainId uint64, timestamp int64, authMsg []byte) error {
 	args := m.Called(transferID, signature, targetChainId, timestamp, authMsg)
 	if args[0] == nil {
 		return nil

--- a/test/mocks/service/prometheus_service_mock.go
+++ b/test/mocks/service/prometheus_service_mock.go
@@ -33,7 +33,7 @@ func (mps *MockPrometheusService) CreateGaugeIfNotExists(opts prometheus.GaugeOp
 }
 
 // CreateSuccessRateGaugeIfNotExists creates new Gauge Metric for Success Rate and registers it in Prometheus if not exists
-func (mps *MockPrometheusService) CreateSuccessRateGaugeIfNotExists(transactionId string, sourceChainId int64, targetChainId int64, asset, metricNameSuffix, metricHelp string) (prometheus.Gauge, error) {
+func (mps *MockPrometheusService) CreateSuccessRateGaugeIfNotExists(transactionId string, sourceChainId, targetChainId uint64, asset, metricNameSuffix, metricHelp string) (prometheus.Gauge, error) {
 	args := mps.Called(transactionId, sourceChainId, targetChainId, asset, metricNameSuffix, metricHelp)
 	return args.Get(0).(prometheus.Gauge), args.Error(1)
 }

--- a/test/mocks/service/transfer_service_mock.go
+++ b/test/mocks/service/transfer_service_mock.go
@@ -76,12 +76,12 @@ func (mts *MockTransferService) ProcessWrappedTransfer(tm transfer.Transfer) err
 	return args.Get(0).(error)
 }
 
-func (mts *MockTransferService) SanityCheckTransfer(tx model.Transaction) (int64, string, error) {
+func (mts *MockTransferService) SanityCheckTransfer(tx model.Transaction) (uint64, string, error) {
 	args := mts.Called(tx)
 	if args.Get(2) == nil {
-		return args.Get(0).(int64), args.Get(1).(string), nil
+		return args.Get(0).(uint64), args.Get(1).(string), nil
 	}
-	return args.Get(0).(int64), args.Get(1).(string), args.Get(2).(error)
+	return args.Get(0).(uint64), args.Get(1).(string), args.Get(2).(error)
 }
 
 func (mts *MockTransferService) InitiateNewTransfer(tm transfer.Transfer) (*entity.Transfer, error) {

--- a/test/test-config/test-config.go
+++ b/test/test-config/test-config.go
@@ -32,7 +32,7 @@ var (
 				Username: "validator",
 			},
 			Clients: config.Clients{
-				Evm: map[int64]config.Evm{
+				Evm: map[uint64]config.Evm{
 					3: {
 						NodeUrl:            "wss://ropsten.infura.io/ws/v3/64364afbcf794ff9a00deabde636b7e1",
 						BlockConfirmations: 5,
@@ -70,7 +70,7 @@ var (
 					},
 				},
 			},
-			EVMs: map[int64]config.BridgeEvm{
+			EVMs: map[uint64]config.BridgeEvm{
 				3: {
 					RouterContractAddress: "B5762f4159e7bFE24B5E7E9a2e829F535744d30e",
 				},


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolay.nedkov@limechain.tech>

**Detailed description**:
Adding changes to usage of ChainIds/NetworkIds to be with type uint64 in order to follow one convention.

**Which issue(s) this PR fixes**:
Fixes #395

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

