### PR TITLE
Disable metrics for NFT transfers and updating e2e's application.yml

### DIFF
--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -182,7 +182,9 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 		return
 	}
 
-	ctw.initSuccessRatePrometheusMetrics(tx, constants.HederaNetworkId, targetChainId, parsedTransfer.Asset)
+	if !parsedTransfer.IsNft {
+		ctw.initSuccessRatePrometheusMetrics(tx, constants.HederaNetworkId, targetChainId, parsedTransfer.Asset)
+	}
 
 	nativeAsset := &config.NativeAsset{
 		ChainId: constants.HederaNetworkId,
@@ -218,6 +220,7 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 	} else {
 		transferMessage, err = ctw.createFungiblePayload(tx.TransactionID, receiverAddress, parsedTransfer.Asset, *nativeAsset, parsedTransfer.AmountOrSerialNum, targetChainId, targetChainAsset)
 	}
+
 	if err != nil {
 		ctw.logger.Errorf("[%s] - Failed to create payload. Error: [%s]", tx.TransactionID, err)
 		return

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,13 +28,14 @@ Name                                      | Description                         
 `hedera.sender.private_key`               | The private key for the account that will be sending assets through the bridge.
 `hedera.topic_id`                         | The configured Bridge Topic. Validators watch & submit signatures to that Topic.
 `evm[]`                                   | The chain id of the EVM network. Used as a key for the following `node.clients.evm[i].*` configuration fields below.
-`evm[].block_confirmations`                | The number of block confirmations to wait for before processing an event for the given EVM network. 
+`evm[].block_confirmations`               | The number of block confirmations to wait for before processing an event for the given EVM network. 
 `evm[].node_url`                          | The endpoint of the node for the given EVM network.
 `evm[].private_key`                       | The private key for the given EVM network.
 `tokens.whbar`                            | The native asset, which represents HBAR. Used as a bridged asset between the two networks.
 `tokens.wtoken`                           | The native asset, which represents a Token on Hedera. Used as a bridged asset between the two networks.
 `tokens.evm_native_token`                 | The address of the EVM native token, which will be used as a bridged asset to Hedera and other EVMs.
 `tokens.nft_token`                        | The Hedera TokenID of the token, used in NFT E2E tests.
+`tokens.nft_serial_number`                | The Hedera Serial Number of the token, used in NFT E2E tests.
 `validator_url`                           | The URL of the Validator node. Used for querying Metadata.
 
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -728,10 +728,10 @@ func Test_EVM_Wrapped_to_EVM_Token(t *testing.T) {
 
 // Test_Hedera_Native_EVM_NFT_Transfer recreates User who wants to portal a Hedera Native NFT to an EVM chain.
 func Test_Hedera_Native_EVM_NFT_Transfer(t *testing.T) {
-	serialNumber := int64(20)
 	now = time.Now()
 	setupEnv := setup.Load()
 	nftToken := setupEnv.NftTokenID.String()
+	serialNumber := setupEnv.NftSerialNumber
 
 	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]
@@ -844,10 +844,10 @@ func Test_Hedera_Native_EVM_NFT_Transfer(t *testing.T) {
 
 // Test_Hedera_EVM_BurnERC721_Transfer recreates User who wants to portal back a Hedera Native NFT from an EVM chain.
 func Test_Hedera_EVM_BurnERC721_Transfer(t *testing.T) {
-	serialNumber := int64(20)
 	now = time.Now()
 	setupEnv := setup.Load()
 	nftToken := setupEnv.NftTokenID.String()
+	serialNumber := setupEnv.NftSerialNumber
 
 	chainId := uint64(80001) // represents Polygon Mumbai Testnet (e2e config must have configuration for that particular network)
 	evm := setupEnv.Clients.EVM[chainId]

--- a/e2e/setup/application.yml
+++ b/e2e/setup/application.yml
@@ -36,6 +36,8 @@ evm:
 tokens:
   whbar: "HBAR"
   wtoken:
+  nft_token:
+  ntf_serial_number:
   evm_native_token:
 validator_url:
 monitoring:

--- a/e2e/setup/config.go
+++ b/e2e/setup/config.go
@@ -92,17 +92,18 @@ func Load() *Setup {
 
 // Setup used by the e2e tests. Preloaded with all necessary dependencies
 type Setup struct {
-	BridgeAccount  hederaSDK.AccountID
-	TopicID        hederaSDK.TopicID
-	TokenID        hederaSDK.TokenID
-	NativeEvmToken string
-	NftTokenID     hederaSDK.TokenID
-	NftFees        map[string]int64
-	FeePercentages map[string]int64
-	Members        []hederaSDK.AccountID
-	Clients        *clients
-	DbValidator    *db_validation.Service
-	AssetMappings  config.Assets
+	BridgeAccount   hederaSDK.AccountID
+	TopicID         hederaSDK.TopicID
+	TokenID         hederaSDK.TokenID
+	NativeEvmToken  string
+	NftTokenID      hederaSDK.TokenID
+	NftSerialNumber int64
+	NftFees         map[string]int64
+	FeePercentages  map[string]int64
+	Members         []hederaSDK.AccountID
+	Clients         *clients
+	DbValidator     *db_validation.Service
+	AssetMappings   config.Assets
 }
 
 // newSetup instantiates new Setup struct
@@ -153,17 +154,18 @@ func newSetup(config Config) (*Setup, error) {
 	dbValidator := db_validation.NewService(config.Hedera.DbValidationProps)
 
 	return &Setup{
-		BridgeAccount:  bridgeAccount,
-		TopicID:        topicID,
-		TokenID:        tokenID,
-		NftTokenID:     nftTokenID,
-		NativeEvmToken: config.Tokens.EvmNativeToken,
-		NftFees:        config.NftFees,
-		FeePercentages: config.FeePercentages,
-		Members:        members,
-		Clients:        clients,
-		DbValidator:    dbValidator,
-		AssetMappings:  config.AssetMappings,
+		BridgeAccount:   bridgeAccount,
+		TopicID:         topicID,
+		TokenID:         tokenID,
+		NftTokenID:      nftTokenID,
+		NftSerialNumber: config.Tokens.NftSerialNumber,
+		NativeEvmToken:  config.Tokens.EvmNativeToken,
+		NftFees:         config.NftFees,
+		FeePercentages:  config.FeePercentages,
+		Members:         members,
+		Clients:         clients,
+		DbValidator:     dbValidator,
+		AssetMappings:   config.AssetMappings,
 	}, nil
 }
 

--- a/e2e/setup/parser/parser.go
+++ b/e2e/setup/parser/parser.go
@@ -30,10 +30,11 @@ type Sender struct {
 }
 
 type Tokens struct {
-	WHbar          string `yaml:"whbar"`
-	WToken         string `yaml:"wtoken"`
-	NftToken       string `yaml:"nft_token"`
-	EvmNativeToken string `yaml:"evm_native_token"`
+	WHbar           string `yaml:"whbar"`
+	WToken          string `yaml:"wtoken"`
+	NftToken        string `yaml:"nft_token"`
+	NftSerialNumber int64  `yaml:"nft_serial_number"`
+	EvmNativeToken  string `yaml:"evm_native_token"`
 }
 
 type E2E struct {


### PR DESCRIPTION
**Detailed description**:
Adding checks to skip creation of metrics for NFTs. And adding nft_token and nft_serial_number in application.yml, and NftSerialNumber to parser.go and replacing the hardcoded serial number with it.

**Checklist**
- [x] Documentation added
- [x] Tests updated

