### PR TITLE
Adding tag 'repeat_interval' and separating routes by it.

### DIFF
--- a/examples/three-validators/monitoring/alertmanager/config.sample.yml
+++ b/examples/three-validators/monitoring/alertmanager/config.sample.yml
@@ -22,7 +22,7 @@ route:
     # - Repeat Interval: LONG - #
     - matchers: [ repeat_interval = "long" ]
       continue: true
-      repeat_interval: 6h
+      repeat_interval: 7d
       receiver: slack-notifications
 
     #########
@@ -37,7 +37,7 @@ route:
     # - Repeat Interval: LONG - #
     - matchers: [ repeat_interval = "long" ]
       continue: true
-      repeat_interval: 6h
+      repeat_interval: 7d
       receiver: email
 
 receivers:

--- a/examples/three-validators/monitoring/alertmanager/config.sample.yml
+++ b/examples/three-validators/monitoring/alertmanager/config.sample.yml
@@ -10,22 +10,32 @@ route:
   group_wait: 5s
   repeat_interval: 30s
   routes:
+    #########
     # Slack #
-    - matchers: [ repeat_interval = "default" ]
+    #########
+
+    # - Repeat Interval: DEFAULT - #
+    - matchers: [ repeat_interval = "", repeat_interval = "default" ]
       continue: true
       receiver: slack-notifications
 
-    - matchers: [ repeat_interval = "big" ]
+    # - Repeat Interval: LONG - #
+    - matchers: [ repeat_interval = "long" ]
       continue: true
       repeat_interval: 6h
       receiver: slack-notifications
 
+    #########
     # Email #
+    #########
+
+    # - Repeat Interval: DEFAULT - #
     - matchers: [ repeat_interval = "default" ]
       continue: true
       receiver: email
 
-    - matchers: [ repeat_interval = "big" ]
+    # - Repeat Interval: LONG - #
+    - matchers: [ repeat_interval = "long" ]
       continue: true
       repeat_interval: 6h
       receiver: email

--- a/examples/three-validators/monitoring/alertmanager/config.sample.yml
+++ b/examples/three-validators/monitoring/alertmanager/config.sample.yml
@@ -1,21 +1,33 @@
 global:
-  resolve_timeout: 800h
+  resolve_timeout: 2h
 
 templates:
   - '/etc/alertmanager/email.html'
 
 route:
   receiver: 'slack-notifications'
-  group_interval: 30s
-  group_wait: 30s
+  group_interval: 5s
+  group_wait: 5s
   repeat_interval: 30s
   routes:
-    - match:
-        severity: critical
+    # Slack #
+    - matchers: [ repeat_interval = "default" ]
       continue: true
       receiver: slack-notifications
-    - match:
-        severity: critical
+
+    - matchers: [ repeat_interval = "big" ]
+      continue: true
+      repeat_interval: 6h
+      receiver: slack-notifications
+
+    # Email #
+    - matchers: [ repeat_interval = "default" ]
+      continue: true
+      receiver: email
+
+    - matchers: [ repeat_interval = "big" ]
+      continue: true
+      repeat_interval: 6h
       receiver: email
 
 receivers:

--- a/examples/three-validators/monitoring/prometheus/rules.yml
+++ b/examples/three-validators/monitoring/prometheus/rules.yml
@@ -9,6 +9,7 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
+#          repeat_interval: 'default'
 #        annotations:
 #          description: "Fee account amount: {{ $value }} HBAR"
 #
@@ -20,6 +21,7 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
+#          repeat_interval: 'default'
 #        annotations:
 #          description: "Operator account amount: {{ $value }} HBAR"
 #
@@ -33,5 +35,6 @@
 #        labels:
 #          severity: 'critical'
 #          group: 'validators'
+#          repeat_interval: 'big'
 #        annotations:
 #          description: "Participation Rate: {{ $value }} %"

--- a/examples/three-validators/monitoring/prometheus/rules.yml
+++ b/examples/three-validators/monitoring/prometheus/rules.yml
@@ -9,7 +9,6 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
-#          repeat_interval: 'default'
 #        annotations:
 #          description: "Fee account amount: {{ $value }} HBAR"
 #
@@ -21,7 +20,6 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
-#          repeat_interval: 'default'
 #        annotations:
 #          description: "Operator account amount: {{ $value }} HBAR"
 #
@@ -35,6 +33,6 @@
 #        labels:
 #          severity: 'critical'
 #          group: 'validators'
-#          repeat_interval: 'big'
+#          repeat_interval: 'long'
 #        annotations:
 #          description: "Participation Rate: {{ $value }} %"

--- a/monitoring/alertmanager/config.sample.yml
+++ b/monitoring/alertmanager/config.sample.yml
@@ -22,7 +22,7 @@ route:
     # - Repeat Interval: LONG - #
     - matchers: [ repeat_interval = "long" ]
       continue: true
-      repeat_interval: 6h
+      repeat_interval: 7d
       receiver: slack-notifications
 
     #########
@@ -37,7 +37,7 @@ route:
     # - Repeat Interval: LONG - #
     - matchers: [ repeat_interval = "long" ]
       continue: true
-      repeat_interval: 6h
+      repeat_interval: 7d
       receiver: email
 
 receivers:

--- a/monitoring/alertmanager/config.sample.yml
+++ b/monitoring/alertmanager/config.sample.yml
@@ -10,22 +10,32 @@ route:
   group_wait: 5s
   repeat_interval: 30s
   routes:
+    #########
     # Slack #
-    - matchers: [ repeat_interval = "default" ]
+    #########
+
+    # - Repeat Interval: DEFAULT - #
+    - matchers: [ repeat_interval = "", repeat_interval = "default" ]
       continue: true
       receiver: slack-notifications
 
-    - matchers: [ repeat_interval = "big" ]
+    # - Repeat Interval: LONG - #
+    - matchers: [ repeat_interval = "long" ]
       continue: true
       repeat_interval: 6h
       receiver: slack-notifications
 
+    #########
     # Email #
+    #########
+
+    # - Repeat Interval: DEFAULT - #
     - matchers: [ repeat_interval = "default" ]
       continue: true
       receiver: email
 
-    - matchers: [ repeat_interval = "big" ]
+    # - Repeat Interval: LONG - #
+    - matchers: [ repeat_interval = "long" ]
       continue: true
       repeat_interval: 6h
       receiver: email

--- a/monitoring/alertmanager/config.sample.yml
+++ b/monitoring/alertmanager/config.sample.yml
@@ -1,21 +1,33 @@
 global:
-  resolve_timeout: 800h
+  resolve_timeout: 2h
 
 templates:
   - '/etc/alertmanager/email.html'
 
 route:
   receiver: 'slack-notifications'
-  group_interval: 30s
-  group_wait: 30s
+  group_interval: 5s
+  group_wait: 5s
   repeat_interval: 30s
   routes:
-    - match:
-        severity: critical
+    # Slack #
+    - matchers: [ repeat_interval = "default" ]
       continue: true
       receiver: slack-notifications
-    - match:
-        severity: critical
+
+    - matchers: [ repeat_interval = "big" ]
+      continue: true
+      repeat_interval: 6h
+      receiver: slack-notifications
+
+    # Email #
+    - matchers: [ repeat_interval = "default" ]
+      continue: true
+      receiver: email
+
+    - matchers: [ repeat_interval = "big" ]
+      continue: true
+      repeat_interval: 6h
       receiver: email
 
 receivers:

--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -9,6 +9,7 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
+#          repeat_interval: 'default'
 #        annotations:
 #          description: "Fee account amount: {{ $value }} HBAR"
 #
@@ -20,6 +21,7 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
+#          repeat_interval: 'default'
 #        annotations:
 #          description: "Operator account amount: {{ $value }} HBAR"
 #
@@ -33,5 +35,6 @@
 #        labels:
 #          severity: 'critical'
 #          group: 'validators'
+#          repeat_interval: 'big'
 #        annotations:
 #          description: "Participation Rate: {{ $value }} %"

--- a/monitoring/prometheus/rules.yml
+++ b/monitoring/prometheus/rules.yml
@@ -9,7 +9,6 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
-#          repeat_interval: 'default'
 #        annotations:
 #          description: "Fee account amount: {{ $value }} HBAR"
 #
@@ -21,7 +20,6 @@
 #        labels:
 #          severity: 'minor'
 #          group: 'account_amounts'
-#          repeat_interval: 'default'
 #        annotations:
 #          description: "Operator account amount: {{ $value }} HBAR"
 #
@@ -35,6 +33,6 @@
 #        labels:
 #          severity: 'critical'
 #          group: 'validators'
-#          repeat_interval: 'big'
+#          repeat_interval: 'long'
 #        annotations:
 #          description: "Participation Rate: {{ $value }} %"


### PR DESCRIPTION
Signed-off-by: Nikolay Nedkov <nikolay.nedkov@limechain.tech>

**Detailed description**:
Adding tag 'repeat_interval' in 'prometheus/alerts.yml'. And separating the routes by the 'repeat_interval' tag in 'alertmanager/config.sample.yml'

**Which issue(s) this PR fixes**:
Fixes #472 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

