### PR TITLE
Feature/unit tests for persistence message

### DIFF
--- a/app/persistence/message/message_test.go
+++ b/app/persistence/message/message_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2022 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package message
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/limechain/hedera-eth-bridge-validator/app/persistence/entity"
+	"github.com/limechain/hedera-eth-bridge-validator/test/helper"
+	"github.com/limechain/hedera-eth-bridge-validator/test/mocks"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"regexp"
+	"testing"
+	"time"
+)
+
+var (
+	repository           *Repository
+	dbConnection         *gorm.DB
+	sqlMock              sqlmock.Sqlmock
+	db                   *sql.DB
+	transferId           = "someTransferId"
+	transfer             = entity.Transfer{}
+	signature            = "someSignature"
+	hash                 = "someHash"
+	signer               = "someSigner"
+	transactionTimestamp = time.Now().UnixNano()
+	columns              = []string{"transfer_id", "hash", "signature", "signer", "transaction_timestamp"}
+	rowArgs              = []driver.Value{transferId, hash, signature, signer, transactionTimestamp}
+	expectedMsg          = &entity.Message{
+		TransferID:           transferId,
+		Transfer:             transfer,
+		Hash:                 hash,
+		Signature:            signature,
+		Signer:               signer,
+		TransactionTimestamp: transactionTimestamp,
+	}
+)
+
+func Test_NewRepository(t *testing.T) {
+	setup()
+
+	actualRepository := NewRepository(dbConnection)
+
+	assert.Equal(t, repository, actualRepository)
+}
+
+func Test_Create(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`INSERT INTO "messages" ("transfer_id","hash","signature","signer","transaction_timestamp") VALUES ($1,$2,$3,$4,$5)`)
+	helper.SqlMockPrepareExec(sqlMock, query, transferId, hash, signature, signer, transactionTimestamp)
+
+	err := repository.Create(expectedMsg)
+
+	assert.Nil(t, err)
+}
+
+func Test_Create_Err(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`INSERT INTO "messages" ("transfer_id","hash","signature","signer","transaction_timestamp") VALUES ($1,$2,$3,$4,$5)`)
+	expectedErr := helper.SqlMockPrepareExecWithErr(sqlMock, query, transferId, hash, signature, signer, transactionTimestamp)
+
+	err := repository.Create(expectedMsg)
+
+	assert.Error(t, err, expectedErr)
+}
+
+func Test_GetMessageWith(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+
+	query := regexp.QuoteMeta(`SELECT * FROM "messages" WHERE transfer_id = $1 and signature = $2 and hash = $3 ORDER BY "messages"."transfer_id" LIMIT 1`)
+	helper.SqlMockPrepareQuery(sqlMock, columns, rowArgs, query, transferId, signature, hash)
+
+	fetchedMsg, err := repository.GetMessageWith(transferId, signature, hash)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedMsg, fetchedMsg)
+}
+
+func Test_GetMessageWith_Err(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`SELECT * FROM "messages" WHERE transfer_id = $1 and signature = $2 and hash = $3 ORDER BY "messages"."transfer_id" LIMIT 1`)
+	expectedErr := helper.SqlMockPrepareQueryWithErr(sqlMock, query, transferId, signature, hash)
+
+	fetchedMsg, err := repository.GetMessageWith(transferId, signature, hash)
+
+	assert.Error(t, err, expectedErr)
+	assert.Nil(t, fetchedMsg)
+}
+
+func Test_Exist(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`SELECT * FROM "messages" WHERE transfer_id = $1 and signature = $2 and hash = $3 ORDER BY "messages"."transfer_id" LIMIT 1`)
+	helper.SqlMockPrepareQuery(sqlMock, columns, rowArgs, query, transferId, signature, hash)
+
+	exist, err := repository.Exist(transferId, signature, hash)
+
+	assert.Nil(t, err)
+	assert.True(t, exist)
+}
+
+func Test_Exist_Err(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`SELECT * FROM "messages" WHERE transfer_id = $1 and signature = $2 and hash = $3 ORDER BY "messages"."transfer_id" LIMIT 1`)
+	returnErr1 := gorm.ErrRecordNotFound
+	expectedErr2 := gorm.ErrInvalidData
+	sqlMock.ExpectQuery(query).WithArgs(transferId, signature, hash).WillReturnError(returnErr1)
+	sqlMock.ExpectQuery(query).WithArgs(transferId, signature, hash).WillReturnError(expectedErr2)
+
+	exist1, err1 := repository.Exist(transferId, signature, hash)
+	exist2, err2 := repository.Exist(transferId, signature, hash)
+
+	assert.Nil(t, err1)
+	assert.False(t, exist1)
+
+	assert.Error(t, err2, expectedErr2)
+	assert.False(t, exist2)
+}
+
+func Test_Get(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`SELECT * FROM "messages" WHERE transfer_id = $1 ORDER BY transaction_timestamp`)
+	helper.SqlMockPrepareQuery(sqlMock, columns, rowArgs, query, transferId)
+	transferForeignKeyQuery := regexp.QuoteMeta(`SELECT * FROM "transfers" WHERE "transfers"."transaction_id" = $1`)
+	sqlMock.ExpectQuery(transferForeignKeyQuery).WithArgs(transferId).WillReturnRows(&sqlmock.Rows{})
+
+	fetchedMessages, err := repository.Get(transferId)
+
+	assert.Nil(t, err)
+	assert.Len(t, fetchedMessages, 1)
+	assert.Equal(t, *expectedMsg, fetchedMessages[0])
+}
+
+func Test_Get_Err(t *testing.T) {
+	setup()
+	defer helper.CheckSqlMockExpectationsMet(sqlMock, t)
+	query := regexp.QuoteMeta(`SELECT * FROM "messages" WHERE transfer_id = $1 ORDER BY transaction_timestamp`)
+	expectedErr := helper.SqlMockPrepareQueryWithErr(sqlMock, query, transferId)
+
+	fetchedMessages, err := repository.Get(transferId)
+
+	assert.Error(t, err, expectedErr)
+	assert.Len(t, fetchedMessages, 0)
+}
+
+func setup() {
+	mocks.Setup()
+	dbConnection, sqlMock, db = helper.SetupSqlMock()
+
+	repository = &Repository{
+		dbClient: dbConnection,
+	}
+}

--- a/test/helper/sqlmock.go
+++ b/test/helper/sqlmock.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helper
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/limechain/hedera-eth-bridge-validator/test/mocks"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func CheckSqlMockExpectationsMet(sqlMock sqlmock.Sqlmock, t *testing.T) {
+	// we make sure that all expectations were met
+	if err := sqlMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}
+
+func SetupSqlMock() (dbConnection *gorm.DB, sqlMock sqlmock.Sqlmock, db *sql.DB) {
+	var err error
+
+	db, sqlMock, err = sqlmock.New()
+	if err != nil {
+		panic("failed to initialize 'sqlmock'")
+	}
+
+	dbConnection, err = gorm.Open(postgres.New(postgres.Config{Conn: db}), &gorm.Config{})
+	if err != nil {
+		panic("failed to open 'gorm.Db' connection")
+	}
+
+	mocks.MDatabase.On("GetConnection").Return(dbConnection)
+	dbConnection = mocks.MDatabase.GetConnection()
+
+	return dbConnection, sqlMock, db
+}
+
+func SqlMockPrepareExec(sqlMock sqlmock.Sqlmock, query string, queryArgs ...driver.Value) {
+	result := sqlmock.NewResult(1, 1)
+	sqlMock.ExpectExec(query).WithArgs(queryArgs...).WillReturnResult(result)
+}
+
+func SqlMockPrepareExecWithErr(sqlMock sqlmock.Sqlmock, query string, queryArgs ...driver.Value) error {
+	err := gorm.ErrInvalidData
+	result := sqlmock.NewResult(0, 0)
+	sqlMock.ExpectExec(query).WithArgs(queryArgs...).WillReturnResult(result).WillReturnError(err)
+
+	return err
+}
+
+func SqlMockPrepareQuery(sqlMock sqlmock.Sqlmock, columns []string, rowArgs []driver.Value, query string, queryArgs ...driver.Value) {
+	msgRow := sqlmock.NewRows(columns).AddRow(rowArgs...)
+	sqlMock.ExpectQuery(query).WithArgs(queryArgs...).WillReturnRows(msgRow)
+}
+
+func SqlMockPrepareQueryWithErr(sqlMock sqlmock.Sqlmock, query string, queryArgs ...driver.Value) error {
+	err := gorm.ErrRecordNotFound
+	sqlMock.ExpectQuery(query).WithArgs(queryArgs...).WillReturnError(err)
+
+	return err
+}


### PR DESCRIPTION
**Detailed description**:
Moving reusable code for SqlMock in 'test/helper/sqlmock.go' and replacing all duplicated code in 'persistence/status_test.go' with the new functions. And implementing unit tests for 'persistence/message.go'.

**Which issue(s) this PR fixes**:
Fixes #437 

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

