### PR TITLE
Handle nanos with leading zeroes

### DIFF
--- a/app/helper/timestamp/helper.go
+++ b/app/helper/timestamp/helper.go
@@ -53,7 +53,7 @@ func FromString(timestamp string) (int64, error) {
 func String(timestamp int64) string {
 	seconds := timestamp / nanosInSecond
 	nano := timestamp % nanosInSecond
-	return fmt.Sprintf("%d.%d", seconds, nano)
+	return fmt.Sprintf("%d.%09d", seconds, nano)
 }
 
 // ToHumanReadable converts the timestamp into human readable string

--- a/app/helper/timestamp/helper_test.go
+++ b/app/helper/timestamp/helper_test.go
@@ -49,6 +49,15 @@ func Test_String(t *testing.T) {
 	assert.Equal(t, validTimestamp, res)
 }
 
+func Test_ReverseStringReturnsInitialValue(t *testing.T) {
+	expected := "1648558453.046349000"
+	timestamp, err := FromString(expected)
+
+	result := String(timestamp)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
 func Test_ToHumanReadable(t *testing.T) {
 	res := ToHumanReadable(timestampInt64)
 	expectedDate := "2020-09-01T01:44:35.008554496Z"


### PR DESCRIPTION
**Detailed description**:

Currently if you try to convert 1648558453046349000 you'd get "1648558453.46349000" (note the missing 0 before the 4).
Zero-padding the nanos fixes that.

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

