### PR TITLE
Exposing 'ReserveAmounts' for assets on 'api/v1/assets' endpoint.

### DIFF
--- a/app/clients/hedera/mirror-node/model/account/account.go
+++ b/app/clients/hedera/mirror-node/model/account/account.go
@@ -16,6 +16,8 @@
 
 package account
 
+import "github.com/limechain/hedera-eth-bridge-validator/constants"
+
 type (
 	// AccountsResponse struct used by the Hedera Mirror node REST API to return information
 	// regarding a given Account
@@ -37,3 +39,13 @@ type (
 		Balance int    `json:"balance"`
 	}
 )
+
+func (b *Balance) GetAccountTokenBalancesByAddress() map[string]int {
+	hederaTokenBalancesByAddress := make(map[string]int)
+	for _, token := range b.Tokens {
+		hederaTokenBalancesByAddress[token.TokenID] = token.Balance
+	}
+	hederaTokenBalancesByAddress[constants.Hbar] = b.Balance
+
+	return hederaTokenBalancesByAddress
+}

--- a/app/domain/client/evm_nft.go
+++ b/app/domain/client/evm_nft.go
@@ -18,9 +18,14 @@ package client
 
 import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"math/big"
 )
 
 type EvmNft interface {
 	Name(opts *bind.CallOpts) (string, error)
 	Symbol(opts *bind.CallOpts) (string, error)
+	BalanceOf(opts *bind.CallOpts, owner common.Address) (*big.Int, error)
+	// TODO: Uncomment when we update the NFTs to extend ERC721Enumerable
+	//TotalSupply(opts *bind.CallOpts) (*big.Int, error)
 }

--- a/app/domain/service/assets.go
+++ b/app/domain/service/assets.go
@@ -17,7 +17,9 @@
 package service
 
 import (
+	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
 	assetModel "github.com/limechain/hedera-eth-bridge-validator/app/model/asset"
+	"math/big"
 )
 
 type Assets interface {
@@ -42,7 +44,13 @@ type Assets interface {
 	// OppositeAsset Gets Opposite asset for passed chain IDs and assetAddress
 	OppositeAsset(sourceChainId uint64, targetChainId uint64, assetAddress string) string
 	// FungibleAssetInfo Gets FungibleAssetInfo
-	FungibleAssetInfo(networkId uint64, assetAddress string) (assetInfo assetModel.FungibleAssetInfo, exist bool)
+	FungibleAssetInfo(networkId uint64, assetAddress string) (assetInfo *assetModel.FungibleAssetInfo, exist bool)
 	// NonFungibleAssetInfo Gets NonFungibleAssetInfo
-	NonFungibleAssetInfo(networkId uint64, assetAddressOrId string) (assetInfo assetModel.NonFungibleAssetInfo, exist bool)
+	NonFungibleAssetInfo(networkId uint64, assetAddressOrId string) (assetInfo *assetModel.NonFungibleAssetInfo, exist bool)
+	// FetchHederaTokenReserveAmount Gets Hedera's Token Reserve Amount
+	FetchHederaTokenReserveAmount(assetId string, mirrorNode client.MirrorNode, isNative bool, hederaTokenBalances map[string]int) (reserveAmount *big.Int, err error)
+	// FetchEvmFungibleReserveAmount Gets EVM's Fungible Token Reserve Amount
+	FetchEvmFungibleReserveAmount(networkId uint64, assetAddress string, isNative bool, evmTokenClient client.EvmFungibleToken, routerContractAddress string) (inLowestDenomination *big.Int, err error)
+	// FetchEvmNonFungibleReserveAmount Gets EVM's Non-Fungible Token Reserve Amount
+	FetchEvmNonFungibleReserveAmount(networkId uint64, assetAddress string, isNative bool, evmTokenClient client.EvmNft, routerContractAddress string) (inLowestDenomination *big.Int, err error)
 }

--- a/app/model/asset/asset.go
+++ b/app/model/asset/asset.go
@@ -16,7 +16,10 @@
 
 package asset
 
-import "github.com/shopspring/decimal"
+import (
+	"github.com/shopspring/decimal"
+	"math/big"
+)
 
 type NativeAsset struct {
 	MinFeeAmountInUsd *decimal.Decimal
@@ -26,14 +29,16 @@ type NativeAsset struct {
 }
 
 type FungibleAssetInfo struct {
-	Name     string `json:"name"`
-	Symbol   string `json:"symbol"`
-	Decimals uint8  `json:"decimals"`
-	IsNative bool   `json:"isNative"`
+	Name          string   `json:"name"`
+	Symbol        string   `json:"symbol"`
+	Decimals      uint8    `json:"decimals"`
+	IsNative      bool     `json:"isNative"`
+	ReserveAmount *big.Int `json:"-"`
 }
 
 type NonFungibleAssetInfo struct {
-	Name     string `json:"name"`
-	Symbol   string `json:"symbol"`
-	IsNative bool   `json:"isNative"`
+	Name          string   `json:"name"`
+	Symbol        string   `json:"symbol"`
+	IsNative      bool     `json:"isNative"`
+	ReserveAmount *big.Int `json:"-"`
 }

--- a/app/process/watcher/assets/watcher.go
+++ b/app/process/watcher/assets/watcher.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package assets
+
+import (
+	"fmt"
+	"github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node/model/account"
+	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
+	qi "github.com/limechain/hedera-eth-bridge-validator/app/domain/queue"
+	"github.com/limechain/hedera-eth-bridge-validator/app/domain/service"
+	"github.com/limechain/hedera-eth-bridge-validator/config"
+	"github.com/limechain/hedera-eth-bridge-validator/constants"
+	log "github.com/sirupsen/logrus"
+	"math/big"
+	"time"
+)
+
+var (
+	sleepTime = 10 * time.Minute
+)
+
+type Watcher struct {
+	mirrorNode                 client.MirrorNode
+	EvmFungibleTokenClients    map[uint64]map[string]client.EvmFungibleToken
+	EvmNonFungibleTokenClients map[uint64]map[string]client.EvmNft
+	configuration              config.Config
+	logger                     *log.Entry
+	assetsService              service.Assets
+}
+
+func NewWatcher(
+	mirrorNode client.MirrorNode,
+	configuration config.Config,
+	EvmFungibleTokenClients map[uint64]map[string]client.EvmFungibleToken,
+	EvmNonFungibleTokenClients map[uint64]map[string]client.EvmNft,
+	assetsService service.Assets,
+) *Watcher {
+
+	return &Watcher{
+		mirrorNode:                 mirrorNode,
+		EvmFungibleTokenClients:    EvmFungibleTokenClients,
+		EvmNonFungibleTokenClients: EvmNonFungibleTokenClients,
+		configuration:              configuration,
+		logger:                     config.GetLoggerFor(fmt.Sprintf("Assets Watcher on interval [%v]", sleepTime)),
+		assetsService:              assetsService,
+	}
+}
+func (pw *Watcher) Watch(q qi.Queue) {
+
+	// there will be no handler, so the q is to implement the interface
+	go func() {
+		pw.watchIteration()
+		time.Sleep(sleepTime)
+	}()
+}
+
+func (pw *Watcher) watchIteration() {
+	//The queue will be not used
+	bridgeAccount, err := pw.getAccount(pw.configuration.Bridge.Hedera.BridgeAccount)
+	if err != nil {
+		return
+	}
+
+	hederaTokenBalances := bridgeAccount.Balance.GetAccountTokenBalancesByAddress()
+	fungibleAssets := pw.assetsService.FungibleNetworkAssets()
+	nonFungibleAssets := pw.assetsService.NonFungibleNetworkAssets()
+	pw.updateAssetInfos(hederaTokenBalances, fungibleAssets, true)
+	pw.updateAssetInfos(hederaTokenBalances, nonFungibleAssets, false)
+}
+
+func (pw *Watcher) updateAssetInfos(hederaTokenBalances map[string]int, assets map[uint64][]string, isFungible bool) {
+	for networkId, networkAssets := range assets {
+		for _, assetAddress := range networkAssets {
+			if pw.assetsService.IsNative(networkId, assetAddress) { // native
+				// set native assets balance
+				pw.updateAssetInfo(networkId, assetAddress, hederaTokenBalances, isFungible, true)
+				wrappedFromNative := pw.assetsService.WrappedFromNative(networkId, assetAddress)
+				for wrappedNetworkId, wrappedAssetAddress := range wrappedFromNative {
+					//set wrapped assets total supply
+					pw.updateAssetInfo(wrappedNetworkId, wrappedAssetAddress, hederaTokenBalances, isFungible, false)
+				}
+			}
+		}
+	}
+}
+
+func (pw *Watcher) getAccount(accountId string) (*account.AccountsResponse, error) {
+	account, e := pw.mirrorNode.GetAccount(accountId)
+	if e != nil {
+		pw.logger.Errorf("Hedera Mirror Node for Account ID [%s] method GetAccount - Error: [%s]", accountId, e)
+		return nil, e
+	}
+	return account, nil
+}
+
+func (pw *Watcher) updateAssetInfo(networkId uint64, assetId string, hederaTokenBalances map[string]int, isFungible bool, isNative bool) {
+	var (
+		reserveAmount *big.Int
+	)
+
+	if networkId == constants.HederaNetworkId {
+		reserveAmount, _ = pw.assetsService.FetchHederaTokenReserveAmount(assetId, pw.mirrorNode, isNative, hederaTokenBalances)
+	} else {
+		if isFungible { // Fungible
+			reserveAmount, _ = pw.assetsService.FetchEvmFungibleReserveAmount(
+				networkId,
+				assetId,
+				isNative,
+				pw.EvmFungibleTokenClients[networkId][assetId],
+				pw.configuration.Bridge.EVMs[networkId].RouterContractAddress,
+			)
+		} else { // Non-Fungible
+			reserveAmount, _ = pw.assetsService.FetchEvmNonFungibleReserveAmount(
+				networkId,
+				assetId,
+				isNative,
+				pw.EvmFungibleTokenClients[networkId][assetId],
+				pw.configuration.Bridge.EVMs[networkId].RouterContractAddress,
+			)
+		}
+	}
+
+	if isFungible {
+		assetInfo, ok := pw.assetsService.FungibleAssetInfo(networkId, assetId)
+		if ok {
+			assetInfo.ReserveAmount = reserveAmount
+		}
+	} else {
+		assetInfo, ok := pw.assetsService.NonFungibleAssetInfo(networkId, assetId)
+		if ok {
+			assetInfo.ReserveAmount = reserveAmount
+		}
+	}
+}

--- a/app/process/watcher/prometheus/watcher.go
+++ b/app/process/watcher/prometheus/watcher.go
@@ -17,10 +17,7 @@
 package prometheus
 
 import (
-	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node/model/account"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
 	qi "github.com/limechain/hedera-eth-bridge-validator/app/domain/queue"
@@ -32,7 +29,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"math/big"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -42,15 +38,15 @@ var (
 )
 
 type Watcher struct {
-	dashboardPolling          time.Duration
-	mirrorNode                client.MirrorNode
-	EVMClients                map[uint64]client.EVM
-	EVMTokenClients           map[uint64]map[string]client.EvmFungibleToken
-	configuration             config.Config
-	prometheusService         service.Prometheus
-	logger                    *log.Entry
-	bridgeAccountBalanceGauge prometheus.Gauge
-	payerAccountBalanceGauge  prometheus.Gauge
+	dashboardPolling           time.Duration
+	mirrorNode                 client.MirrorNode
+	EvmFungibleTokenClients    map[uint64]map[string]client.EvmFungibleToken
+	EvmNonFungibleTokenClients map[uint64]map[string]client.EvmNft
+	configuration              config.Config
+	prometheusService          service.Prometheus
+	logger                     *log.Entry
+	bridgeAccountBalanceGauge  prometheus.Gauge
+	payerAccountBalanceGauge   prometheus.Gauge
 	// A mapping, storing all Prometheus Gauges by AccountId
 	monitoredAccountsGauges map[string]monitoredAccountsInfo
 	// A mapping, storing all network ID - asset address - metric name
@@ -68,24 +64,24 @@ func NewWatcher(
 	mirrorNode client.MirrorNode,
 	configuration config.Config,
 	prometheusService service.Prometheus,
-	EVMClients map[uint64]client.EVM,
-	EVMTokenClients map[uint64]map[string]client.EvmFungibleToken,
+	EvmFungibleTokenClients map[uint64]map[string]client.EvmFungibleToken,
+	EvmNonFungibleTokenClients map[uint64]map[string]client.EvmNft,
 	assetsService service.Assets,
 ) *Watcher {
 
 	return &Watcher{
-		dashboardPolling:          dashboardPolling,
-		mirrorNode:                mirrorNode,
-		EVMClients:                EVMClients,
-		EVMTokenClients:           EVMTokenClients,
-		configuration:             configuration,
-		prometheusService:         prometheusService,
-		logger:                    config.GetLoggerFor(fmt.Sprintf("Prometheus Metrics Watcher on interval [%s]", dashboardPolling)),
-		payerAccountBalanceGauge:  initPayerAccountBalanceGauge(prometheusService, configuration),
-		bridgeAccountBalanceGauge: initBridgeAccountBalanceGauge(prometheusService, configuration),
-		monitoredAccountsGauges:   initMonitoredAccountsGauges(configuration, prometheusService),
-		assetsMetrics:             make(map[uint64]map[string]string),
-		assetsService:             assetsService,
+		dashboardPolling:           dashboardPolling,
+		mirrorNode:                 mirrorNode,
+		EvmFungibleTokenClients:    EvmFungibleTokenClients,
+		EvmNonFungibleTokenClients: EvmNonFungibleTokenClients,
+		configuration:              configuration,
+		prometheusService:          prometheusService,
+		logger:                     config.GetLoggerFor(fmt.Sprintf("Prometheus Metrics Watcher on interval [%s]", dashboardPolling)),
+		payerAccountBalanceGauge:   initPayerAccountBalanceGauge(prometheusService, configuration),
+		bridgeAccountBalanceGauge:  initBridgeAccountBalanceGauge(prometheusService, configuration),
+		monitoredAccountsGauges:    initMonitoredAccountsGauges(configuration, prometheusService),
+		assetsMetrics:              make(map[uint64]map[string]string),
+		assetsService:              assetsService,
 	}
 }
 
@@ -147,13 +143,19 @@ func (pw Watcher) Watch(q qi.Queue) {
 
 func (pw Watcher) beginWatching() {
 	//The queue will be not used
-	pw.registerAssetsMetrics()
+	pw.registerAllAssetsMetrics()
 	pw.setMetrics()
 }
 
-func (pw Watcher) registerAssetsMetrics() {
+func (pw Watcher) registerAllAssetsMetrics() {
 	fungibleAssets := pw.assetsService.FungibleNetworkAssets()
-	for networkId, networkAssets := range fungibleAssets {
+	nonFungibleAssets := pw.assetsService.NonFungibleNetworkAssets()
+	pw.registerAssetMetrics(fungibleAssets, true)
+	pw.registerAssetMetrics(nonFungibleAssets, false)
+}
+
+func (pw Watcher) registerAssetMetrics(assets map[uint64][]string, isFungible bool) {
+	for networkId, networkAssets := range assets {
 		for _, assetAddress := range networkAssets {
 			if pw.assetsService.IsNative(networkId, assetAddress) { // native
 				// register native assets balance
@@ -163,6 +165,7 @@ func (pw Watcher) registerAssetsMetrics() {
 					assetAddress,
 					constants.BalanceAssetMetricNameSuffix,
 					constants.BalanceAssetMetricHelpPrefix,
+					isFungible,
 				)
 				wrappedFromNative := pw.assetsService.WrappedFromNative(networkId, assetAddress)
 				for wrappedNetworkId, wrappedAssetAddress := range wrappedFromNative {
@@ -173,6 +176,7 @@ func (pw Watcher) registerAssetsMetrics() {
 						wrappedAssetAddress,
 						constants.SupplyAssetMetricNameSuffix,
 						constants.SupplyAssetMetricsHelpPrefix,
+						isFungible,
 					)
 				}
 			}
@@ -186,19 +190,34 @@ func (pw Watcher) registerAssetMetric(
 	assetAddress string,
 	metricNameCnt string,
 	metricHelpCnt string,
+	isFungible bool,
 ) {
 	if assetAddress != constants.Hbar { // skip HBAR
-		assetInfo, exist := pw.assetsService.FungibleAssetInfo(wrappedNetworkId, assetAddress)
+		var (
+			name, symbol string
+		)
+		if isFungible {
+			assetInfo, exist := pw.assetsService.FungibleAssetInfo(wrappedNetworkId, assetAddress)
+			if !exist {
+				return
+			}
+			name = assetInfo.Name
+			symbol = assetInfo.Symbol
+		} else {
 
-		if !exist {
-			return
+			assetInfo, exist := pw.assetsService.NonFungibleAssetInfo(wrappedNetworkId, assetAddress)
+			if !exist {
+				return
+			}
+			name = assetInfo.Name
+			symbol = assetInfo.Symbol
 		}
 
 		metricName, metricHelp := getMetricData(
 			nativeNetworkId,
 			wrappedNetworkId,
 			assetAddress,
-			assetInfo.Name,
+			name,
 			metricNameCnt,
 			metricHelpCnt,
 		)
@@ -210,7 +229,7 @@ func (pw Watcher) registerAssetMetric(
 			Name: metricName,
 			Help: metricHelp,
 			ConstLabels: prometheus.Labels{
-				constants.AssetMetricLabelKey: assetInfo.Symbol,
+				constants.AssetMetricLabelKey: symbol,
 			},
 		})
 	}
@@ -248,13 +267,12 @@ func (pw Watcher) setMetrics() {
 
 	for {
 		payerAccount, errPayerAcc := pw.getAccount(pw.configuration.Bridge.Hedera.PayerAccount)
-		bridgeAccount, errBridgeAcc := pw.getAccount(pw.configuration.Bridge.Hedera.BridgeAccount)
-
 		if errPayerAcc == nil {
 			pw.payerAccountBalanceGauge.Set(pw.getAccountBalance(payerAccount))
 		}
-		if errBridgeAcc == nil {
-			pw.bridgeAccountBalanceGauge.Set(pw.getAccountBalance(bridgeAccount))
+		hbarAssetInfo, ok := pw.assetsService.FungibleAssetInfo(constants.HederaNetworkId, constants.Hbar)
+		if ok {
+			pw.bridgeAccountBalanceGauge.Set(metrics.ConvertToHbar(int(hbarAssetInfo.ReserveAmount.Int64())))
 		}
 
 		for _, monitoredAccountInfo := range pw.monitoredAccountsGauges {
@@ -264,7 +282,7 @@ func (pw Watcher) setMetrics() {
 			}
 		}
 
-		pw.setAssetsMetrics(bridgeAccount)
+		pw.setAllAssetsMetrics()
 
 		pw.logger.Infoln("Dashboard Polling interval: ", pw.dashboardPolling)
 		time.Sleep(pw.dashboardPolling)
@@ -286,17 +304,26 @@ func (pw Watcher) getAccountBalance(account *account.AccountsResponse) float64 {
 	return balance
 }
 
-func (pw Watcher) setAssetsMetrics(bridgeAccount *account.AccountsResponse) {
+func (pw Watcher) setAllAssetsMetrics() {
 	fungibleAssets := pw.assetsService.FungibleNetworkAssets()
-	for networkId, networkAssets := range fungibleAssets {
+	nonFungibleAssets := pw.assetsService.NonFungibleNetworkAssets()
+	pw.setAssetsMetrics(fungibleAssets, true)
+	pw.setAssetsMetrics(nonFungibleAssets, false)
+}
+
+func (pw Watcher) setAssetsMetrics(assets map[uint64][]string, isFungible bool) {
+	for networkId, networkAssets := range assets {
 		for _, assetAddress := range networkAssets {
+			if assetAddress == constants.Hbar { // skip HBAR
+				continue
+			}
 			if pw.assetsService.IsNative(networkId, assetAddress) { // native
 				// set native assets balance
-				pw.prepareAndSetAssetMetric(networkId, assetAddress, bridgeAccount, true)
+				pw.prepareAndSetAssetMetric(networkId, assetAddress, isFungible, true)
 				wrappedFromNative := pw.assetsService.WrappedFromNative(networkId, assetAddress)
 				for wrappedNetworkId, wrappedAssetAddress := range wrappedFromNative {
 					//set wrapped assets total supply
-					pw.prepareAndSetAssetMetric(wrappedNetworkId, wrappedAssetAddress, bridgeAccount, false)
+					pw.prepareAndSetAssetMetric(wrappedNetworkId, wrappedAssetAddress, isFungible, false)
 				}
 			}
 		}
@@ -305,143 +332,45 @@ func (pw Watcher) setAssetsMetrics(bridgeAccount *account.AccountsResponse) {
 
 func (pw Watcher) prepareAndSetAssetMetric(networkId uint64,
 	assetAddress string,
-	bridgeAccount *account.AccountsResponse,
+	isFungible,
 	isNative bool,
 ) {
+	var value float64
+	assetMetric := pw.prometheusService.GetGauge(pw.assetsMetrics[networkId][assetAddress])
+	var (
+		ReserveAmountInLowestDenomination *big.Int
+		decimals                          uint8
+	)
+	if isFungible {
+		assetInfo, ok := pw.assetsService.FungibleAssetInfo(networkId, assetAddress)
+		if ok {
+			ReserveAmountInLowestDenomination = assetInfo.ReserveAmount
+			decimals = assetInfo.Decimals
+		}
 
-	if assetAddress != constants.Hbar { // skip HBAR
-		assetMetric := pw.prometheusService.GetGauge(pw.assetsMetrics[networkId][assetAddress])
-		value, e := pw.getAssetMetricValue(networkId, assetAddress, bridgeAccount, isNative)
-		if e != nil {
-			pw.logger.Errorf("Network ID [%d] and asset [%s] for getAssetMetricValue Error: [%s]", networkId, assetAddress, e)
+	} else {
+		decimals = 1
+		assetInfo, ok := pw.assetsService.NonFungibleAssetInfo(networkId, assetAddress)
+		if ok {
+			ReserveAmountInLowestDenomination = assetInfo.ReserveAmount
+		}
+	}
+
+	if decimals != 0 {
+		converted, err := metrics.ConvertBasedOnDecimal(ReserveAmountInLowestDenomination, decimals)
+		if err != nil {
+			pw.logger.Errorf("Failed to convert asset ReserveAmount to decimal. Error: %s", err)
 			return
 		}
-		logString := constants.SupplyAssetMetricsHelpPrefix
-		if isNative {
-			logString = constants.BalanceAssetMetricHelpPrefix
-		}
-
-		assetMetric.Set(value)
-		pw.logger.Infof("The Assets with ID [%s] has %s = %f", assetAddress, logString, value)
-	}
-}
-
-func (pw Watcher) getAssetMetricValue(
-	networkId uint64,
-	assetAddress string,
-	bridgeAccount *account.AccountsResponse,
-	isNative bool,
-) (value float64, err error) {
-	var (
-		decimal uint8
-	)
-	if networkId != constants.HederaNetworkId { // EVM
-		dec, e := pw.EVMTokenClients[networkId][assetAddress].Decimals(&bind.CallOpts{})
-		if e != nil {
-			pw.logger.Errorf("EVM with networkId [%d] for asset [%s], and method Decimals - Error: [%s]", networkId, assetAddress, e)
-			return 0, e
-		}
-		decimal = dec
+		value = *converted
+	} else {
+		value, _ = new(big.Float).SetInt(ReserveAmountInLowestDenomination).Float64()
 	}
 
-	if networkId == constants.HederaNetworkId { //Hedera
-		if isNative { // Hedera native balance
-			value, err = pw.getHederaTokenBalance(assetAddress, bridgeAccount)
-		} else { // Hedera wrapped total supply
-			value, err = pw.getHederaTokenSupply(assetAddress)
-		}
-	} else { // EVM
-		if isNative { // EVM native balance
-			value, err = pw.getEVMBalance(networkId, decimal, assetAddress)
-		} else { // EVM wrapped total supply
-			value, err = pw.getEVMSupply(decimal, networkId, assetAddress)
-		}
+	logString := constants.SupplyAssetMetricsHelpPrefix
+	if isNative {
+		logString = constants.BalanceAssetMetricHelpPrefix
 	}
-	return value, err
-}
-
-func (pw Watcher) getHederaTokenBalance(assetAddress string, bridgeAccount *account.AccountsResponse) (value float64, err error) {
-	if bridgeAccount == nil {
-		return 0, errors.New(fmt.Sprintf("Bridge account cannot be nil"))
-	}
-	for _, token := range bridgeAccount.Balance.Tokens {
-		if assetAddress == token.TokenID {
-			asset, e := pw.mirrorNode.GetToken(assetAddress)
-			if e != nil {
-				pw.logger.Errorf("Hedera Mirror Node for asset [%s] method GetToken - Error: [%s]", assetAddress, e)
-				return 0, e
-			}
-			dec, e := strconv.Atoi(asset.Decimals)
-			if e != nil {
-				pw.logger.Errorf("Hedera asset [%s] convert decimals to string method Atio - Error: [%s]", assetAddress, e)
-				return 0, e
-			}
-			decimal := uint8(dec)
-
-			b := big.NewInt(int64(token.Balance))
-			balance, e := metrics.ConvertBasedOnDecimal(b, decimal)
-			if e != nil {
-				pw.logger.Errorf("Hedera asset [%s] balance ConvertBasedOnDecimal - Error: [%s]", assetAddress, e)
-				return 0, e
-			}
-			value = *balance
-		}
-	}
-	return value, nil
-}
-
-func (pw Watcher) getHederaTokenSupply(assetAddress string) (float64, error) {
-	asset, e := pw.mirrorNode.GetToken(assetAddress)
-	if e != nil {
-		pw.logger.Errorf("Hedera Mirror Node for asset [%s] method GetToken - Error: [%s]", assetAddress, e)
-		return 0, e
-	}
-	dec, e := strconv.Atoi(asset.Decimals)
-	if e != nil {
-		pw.logger.Errorf("Hedera asset [%s] convert decimals to string, method Atio - Error: [%s]", assetAddress, e)
-		return 0, e
-	}
-	decimal := uint8(dec)
-
-	ts, ok := new(big.Int).SetString(asset.TotalSupply, 10)
-	if !ok {
-		pw.logger.Errorf(`"Hedera assed [%s] total supply SetString - Error": [%s].`, assetAddress, asset.TotalSupply)
-		return 0, e
-	}
-	totalSupply, e := metrics.ConvertBasedOnDecimal(ts, decimal)
-	if e != nil {
-		pw.logger.Errorf("Hedera asset [%s] total supply ConvertBasedOnDecimal - Error: [%s]", assetAddress, e)
-		return 0, e
-	}
-	return *totalSupply, nil
-}
-
-func (pw Watcher) getEVMBalance(networkId uint64, decimal uint8, assetAddress string) (float64, error) {
-	address := common.HexToAddress(pw.configuration.Bridge.EVMs[networkId].RouterContractAddress)
-
-	b, e := pw.EVMTokenClients[networkId][assetAddress].BalanceOf(&bind.CallOpts{}, address)
-	if e != nil {
-		pw.logger.Errorf("EVM with networkId [%d] for asset [%s], and method BalanceOf - Error: [%s]", networkId, assetAddress, e)
-		return 0, e
-	}
-	balance, e := metrics.ConvertBasedOnDecimal(b, decimal)
-	if e != nil {
-		pw.logger.Errorf("EVM with networkId [%d] asset [%s] for balance, and method ConvertBasedOnDecimal - Error: [%s]", networkId, assetAddress, e)
-		return 0, e
-	}
-	return *balance, nil
-}
-
-func (pw Watcher) getEVMSupply(decimal uint8, networkId uint64, assetAddress string) (float64, error) {
-	ts, e := pw.EVMTokenClients[networkId][assetAddress].TotalSupply(&bind.CallOpts{})
-	if e != nil {
-		pw.logger.Errorf("EVM networkId [%d] asset [%s] for method TotalSupply - Error: [%s]", networkId, assetAddress, e)
-		return 0, e
-	}
-	totalSupply, e := metrics.ConvertBasedOnDecimal(ts, decimal)
-	if e != nil {
-		pw.logger.Errorf("EVM networkId [%d] asset [%s] for total supply method ConvertBasedOnDecimal - Error: [%s]", networkId, assetAddress, e)
-		return 0, e
-	}
-	return *totalSupply, nil
+	assetMetric.Set(value)
+	pw.logger.Infof("The Assets with ID [%s] has %s = %f", assetAddress, logString, value)
 }

--- a/app/router/assets/assets.go
+++ b/app/router/assets/assets.go
@@ -35,6 +35,8 @@ type fungibleBridgeDetails struct {
 	FeePercentage feePercentageInfo `json:"feePercentage"`
 	MinAmount     string            `json:"minAmount"`
 	Networks      map[uint64]string `json:"networks"`
+	IsNative      bool              `json:"isNative"`
+	ReserveAmount string            `json:"reserveAmount"`
 }
 
 type feePercentageInfo struct {
@@ -44,8 +46,10 @@ type feePercentageInfo struct {
 
 type nonFungibleBridgeDetails struct {
 	*asset.NonFungibleAssetInfo
-	Fee      int64             `json:"fee"`
-	Networks map[uint64]string `json:"networks"`
+	Fee           int64             `json:"fee"`
+	Networks      map[uint64]string `json:"networks"`
+	IsNative      bool              `json:"isNative"`
+	ReserveAmount string            `json:"reserveAmount"`
 }
 
 type networkAssets struct {
@@ -94,10 +98,11 @@ func generateResponseContent(bridgeConfig parser.Bridge, assetsService service.A
 				feePercentage := nativeAsset.FeePercentage
 
 				fungibleAssetDetails := fungibleBridgeDetails{
-					FungibleAssetInfo: &fungibleAssetInfo,
+					FungibleAssetInfo: fungibleAssetInfo,
 					FeePercentage:     feePercentageInfo{feePercentage, constants.FeeMaxPercentage},
 					MinAmount:         minAmount.MinAmountWithFee.String(),
 					Networks:          bridgeTokenInfo.Networks,
+					ReserveAmount:     fungibleAssetInfo.ReserveAmount.String(),
 				}
 				response[networkId].Fungible[assetAddress] = fungibleAssetDetails
 			}
@@ -116,12 +121,13 @@ func generateResponseContent(bridgeConfig parser.Bridge, assetsService service.A
 				}
 
 				bridgeTokenInfo := bridgeConfig.Networks[networkId].Tokens.Nft[nativeAddress]
-				fungibleAssetDetails := nonFungibleBridgeDetails{
-					NonFungibleAssetInfo: &nonFungibleAssetInfo,
+				nonFungibleAssetDetails := nonFungibleBridgeDetails{
+					NonFungibleAssetInfo: nonFungibleAssetInfo,
 					Fee:                  bridgeTokenInfo.Fee,
 					Networks:             bridgeTokenInfo.Networks,
+					ReserveAmount:        nonFungibleAssetInfo.ReserveAmount.String(),
 				}
-				response[networkId].NonFungible[assetAddress] = fungibleAssetDetails
+				response[networkId].NonFungible[assetAddress] = nonFungibleAssetDetails
 			}
 		}
 	}

--- a/app/services/assets/assets_test.go
+++ b/app/services/assets/assets_test.go
@@ -19,6 +19,7 @@ package assets
 import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node/model/account"
 	"github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node/model/token"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
 	"github.com/limechain/hedera-eth-bridge-validator/config"
@@ -40,15 +41,24 @@ var (
 	evmClients              = make(map[uint64]client.EVM)
 	evmCoreClients          = make(map[uint64]client.Core)
 	evmFungibleTokenClients = make(map[uint64]map[string]client.EvmFungibleToken)
-	evmNFTClients           = make(map[uint64]map[string]client.EvmNft)
+	evmNftClients           = make(map[uint64]map[string]client.EvmNft)
 	hederaPercentages       = make(map[string]int64)
+	hederaAccount           = account.AccountsResponse{
+		Account: testConstants.BridgeAccountId,
+		Balance: account.Balance{
+			Balance:   int(testConstants.ReserveAmount),
+			Timestamp: "",
+			Tokens:    []account.AccountToken{},
+		},
+	}
+	hederaTokenBalances = make(map[string]int)
 )
 
 func Test_New(t *testing.T) {
 	setup()
 	setupClientMocks()
 
-	actualService := NewService(testConstants.ParserBridge.Networks, hederaPercentages, routerClients, mocks.MHederaMirrorClient, evmFungibleTokenClients, evmNFTClients)
+	actualService := NewService(testConstants.ParserBridge.Networks, testConstants.ParserBridge.Networks[0].BridgeAccount, hederaPercentages, routerClients, mocks.MHederaMirrorClient, evmFungibleTokenClients, evmNftClients)
 
 	assert.Equal(t, serviceInstance.nativeToWrapped, actualService.nativeToWrapped)
 	assert.Equal(t, serviceInstance.wrappedToNative, actualService.wrappedToNative)
@@ -206,6 +216,96 @@ func Test_NonFungibleAssetInfo(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func Test_FetchEvmFungibleReserveAmount_Native(t *testing.T) {
+	setup()
+	setupClientMocks()
+
+	routerContractAddress := "router"
+	asset := testConstants.NetworkEthereumFungibleNativeToken
+	tokenClient := evmFungibleTokenClients[testConstants.EthereumNetworkId][asset]
+	expectedReserveAmount := testConstants.ReserveAmountBigInt
+	tokenClient.(*testClient.MockEvmFungibleToken).On("BalanceOf", &bind.CallOpts{}, common.HexToAddress(routerContractAddress)).Return(expectedReserveAmount, nil)
+
+	actual, err := serviceInstance.FetchEvmFungibleReserveAmount(testConstants.EthereumNetworkId, asset, true, tokenClient, routerContractAddress)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedReserveAmount, actual)
+}
+
+func Test_FetchEvmFungibleReserveAmount_Wrapped(t *testing.T) {
+	setup()
+	setupClientMocks()
+
+	routerContractAddress := "router"
+	asset := testConstants.NetworkEthereumFungibleWrappedTokenForNetworkHedera
+	tokenClient := evmFungibleTokenClients[testConstants.EthereumNetworkId][asset]
+	expectedReserveAmount := testConstants.ReserveAmountBigInt
+	tokenClient.(*testClient.MockEvmFungibleToken).On("TotalSupply", &bind.CallOpts{}).Return(expectedReserveAmount, nil)
+
+	actual, err := serviceInstance.FetchEvmFungibleReserveAmount(testConstants.EthereumNetworkId, asset, false, tokenClient, routerContractAddress)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedReserveAmount, actual)
+}
+
+func Test_FetchEvmNonFungibleReserveAmount_Native(t *testing.T) {
+	setup()
+	setupClientMocks()
+
+	routerContractAddress := "router"
+	asset := testConstants.NetworkPolygonWrappedNonFungibleTokenForHedera
+	tokenClient := evmNftClients[testConstants.PolygonNetworkId][asset]
+	expectedReserveAmount := testConstants.ReserveAmountBigInt
+	tokenClient.(*testClient.MockEvmNonFungibleToken).On("BalanceOf", &bind.CallOpts{}, common.HexToAddress(routerContractAddress)).Return(expectedReserveAmount, nil)
+
+	actual, err := serviceInstance.FetchEvmNonFungibleReserveAmount(testConstants.PolygonNetworkId, asset, true, tokenClient, routerContractAddress)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedReserveAmount, actual)
+}
+
+func Test_FetchEvmNonFungibleReserveAmount_Wrapped(t *testing.T) {
+	setup()
+	setupClientMocks()
+
+	routerContractAddress := "router"
+	asset := testConstants.NetworkPolygonWrappedNonFungibleTokenForHedera
+	tokenClient := evmNftClients[testConstants.PolygonNetworkId][asset]
+	expectedReserveAmount := testConstants.ReserveAmountWrappedNFTBigInt
+
+	actual, err := serviceInstance.FetchEvmNonFungibleReserveAmount(testConstants.PolygonNetworkId, asset, false, tokenClient, routerContractAddress)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedReserveAmount, actual)
+}
+
+func Test_FetchHederaTokenReserveAmount_Native(t *testing.T) {
+	setup()
+	setupClientMocks()
+
+	asset := constants.Hbar
+	expectedReserveAmount := testConstants.ReserveAmountBigInt
+	actual, err := serviceInstance.FetchHederaTokenReserveAmount(asset, mocks.MHederaMirrorClient, true, hederaTokenBalances)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedReserveAmount, actual)
+}
+
+func Test_FetchHederaTokenReserveAmount_Wrapped(t *testing.T) {
+	setup()
+	setupClientMocks()
+
+	asset := constants.Hbar
+	expectedReserveAmount := testConstants.ReserveAmountBigInt
+	mocks.MHederaMirrorClient.On("GetToken", asset).Return(&token.TokenResponse{
+		TotalSupply: expectedReserveAmount.String(),
+	})
+	actual, err := serviceInstance.FetchHederaTokenReserveAmount(asset, mocks.MHederaMirrorClient, false, hederaTokenBalances)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedReserveAmount, actual)
+}
+
 func setup() {
 	mocks.Setup()
 	helper.SetupNetworks()
@@ -218,31 +318,40 @@ func setup() {
 		fungibleAssetInfos:       testConstants.FungibleAssetInfos,
 		nonFungibleNetworkAssets: testConstants.NonFungibleNetworkAssets,
 		nonFungibleAssetInfos:    testConstants.NonFungibleAssetInfos,
+		bridgeAccountId:          testConstants.BridgeAccountId,
 		logger:                   config.GetLoggerFor("Assets Service"),
 	}
 }
 
 func setupClientMocks() {
-	for networkId := range testConstants.Networks {
+	for networkId, networkInfo := range testConstants.Networks {
 		if networkId != constants.HederaNetworkId {
 			evmFungibleTokenClients[networkId] = make(map[string]client.EvmFungibleToken)
-			evmNFTClients[networkId] = make(map[string]client.EvmNft)
+			evmNftClients[networkId] = make(map[string]client.EvmNft)
 			evmClients[networkId] = &testClient.MockEVM{}
 			evmCoreClients[networkId] = &testClient.MockEVMCore{}
 			evmClients[networkId].(*testClient.MockEVM).On("GetClient").Return(evmCoreClients[networkId])
 			routerClients[networkId] = new(testClient.MockDiamondRouter)
 		}
 
+		// FUNGIBLE //
 		fungibleAssets := testConstants.FungibleNetworkAssets[networkId]
 		for _, asset := range fungibleAssets {
 			hederaPercentages[asset] = testConstants.FeePercentage
+			assetInfo := testConstants.FungibleAssetInfos[networkId][asset]
+			isNative := assetInfo.IsNative
 			if networkId == constants.HederaNetworkId {
+				hederaTokenBalances[asset] = int(testConstants.ReserveAmount)
+				hederaAccount.Balance.Tokens = append(hederaAccount.Balance.Tokens, account.AccountToken{
+					TokenID: asset,
+					Balance: int(testConstants.ReserveAmount),
+				})
 				// Hedera
 				tokenResponse := token.TokenResponse{
 					TokenID:     asset,
 					Name:        asset,
 					Symbol:      asset,
-					TotalSupply: "100",
+					TotalSupply: testConstants.ReserveAmountStr,
 					Decimals:    strconv.Itoa(int(constants.HederaDefaultDecimals)),
 				}
 				mocks.MHederaMirrorClient.On("GetToken", asset).Return(&tokenResponse, nil)
@@ -254,6 +363,11 @@ func setupClientMocks() {
 			evmFungibleTokenClients[networkId][asset].(*testClient.MockEvmFungibleToken).On("Name", &bind.CallOpts{}).Return(asset, nil)
 			evmFungibleTokenClients[networkId][asset].(*testClient.MockEvmFungibleToken).On("Symbol", &bind.CallOpts{}).Return(asset, nil)
 			evmFungibleTokenClients[networkId][asset].(*testClient.MockEvmFungibleToken).On("Decimals", &bind.CallOpts{}).Return(constants.EvmDefaultDecimals, nil)
+			if isNative {
+				evmFungibleTokenClients[networkId][asset].(*testClient.MockEvmFungibleToken).On("BalanceOf", &bind.CallOpts{}, common.HexToAddress(networkInfo.RouterContractAddress)).Return(testConstants.ReserveAmountBigInt, nil)
+			} else {
+				evmFungibleTokenClients[networkId][asset].(*testClient.MockEvmFungibleToken).On("TotalSupply", &bind.CallOpts{}).Return(testConstants.ReserveAmountBigInt, nil)
+			}
 			tokenFeeDataResult := struct {
 				ServiceFeePercentage *big.Int
 				FeesAccrued          *big.Int
@@ -268,16 +382,25 @@ func setupClientMocks() {
 			routerClients[networkId].(*testClient.MockDiamondRouter).On("TokenFeeData", &bind.CallOpts{}, common.HexToAddress(asset)).Return(tokenFeeDataResult, nil)
 		}
 
+		// NON-FUNGIBLE //
 		nonFungibleAssets := testConstants.NonFungibleNetworkAssets[networkId]
 		for _, asset := range nonFungibleAssets {
+			assetInfo := testConstants.NonFungibleAssetInfos[networkId][asset]
+			isNative := assetInfo.IsNative
 			hederaPercentages[asset] = testConstants.FeePercentage
 			if networkId == constants.HederaNetworkId {
+				hederaTokenBalances[asset] = int(testConstants.ReserveAmount)
+				hederaAccount.Balance.Tokens = append(hederaAccount.Balance.Tokens, account.AccountToken{
+					TokenID: asset,
+					Balance: int(testConstants.ReserveAmount),
+				})
+
 				// Hedera
 				tokenResponse := token.TokenResponse{
 					TokenID:     asset,
 					Name:        asset,
 					Symbol:      asset,
-					TotalSupply: "100",
+					TotalSupply: testConstants.ReserveAmountStr,
 					Decimals:    "0",
 				}
 				mocks.MHederaMirrorClient.On("GetToken", asset).Return(&tokenResponse, nil)
@@ -285,9 +408,9 @@ func setupClientMocks() {
 			}
 
 			// EVM
-			evmNFTClients[networkId][asset] = new(testClient.MockEvmNonFungibleToken)
-			evmNFTClients[networkId][asset].(*testClient.MockEvmNonFungibleToken).On("Name", &bind.CallOpts{}).Return(asset, nil)
-			evmNFTClients[networkId][asset].(*testClient.MockEvmNonFungibleToken).On("Symbol", &bind.CallOpts{}).Return(asset, nil)
+			evmNftClients[networkId][asset] = new(testClient.MockEvmNonFungibleToken)
+			evmNftClients[networkId][asset].(*testClient.MockEvmNonFungibleToken).On("Name", &bind.CallOpts{}).Return(asset, nil)
+			evmNftClients[networkId][asset].(*testClient.MockEvmNonFungibleToken).On("Symbol", &bind.CallOpts{}).Return(asset, nil)
 			tokenFeeDataResult := struct {
 				ServiceFeePercentage *big.Int
 				FeesAccrued          *big.Int
@@ -295,7 +418,14 @@ func setupClientMocks() {
 				Accumulator          *big.Int
 			}{big.NewInt(testConstants.FeePercentage), big.NewInt(0), big.NewInt(0), big.NewInt(0)}
 			routerClients[networkId].(*testClient.MockDiamondRouter).On("TokenFeeData", &bind.CallOpts{}, common.HexToAddress(asset)).Return(tokenFeeDataResult, nil)
+			if isNative {
+				evmNftClients[networkId][asset].(*testClient.MockEvmNonFungibleToken).On("BalanceOf", &bind.CallOpts{}, common.HexToAddress(networkInfo.RouterContractAddress)).Return(testConstants.ReserveAmountBigInt, nil)
+			} /* else { // TODO: Uncomment the line below when we update the NFTs to extend ERC721Enumerable
+				evmNftClients[networkId][asset].(*testClient.MockEvmFungibleToken).On("TotalSupply", &bind.CallOpts{}).Return(testConstants.ReserveAmountBigInt, nil)
+			} */
 		}
 
 	}
+
+	mocks.MHederaMirrorClient.On("GetAccount", testConstants.BridgeAccountId).Return(&hederaAccount, nil)
 }

--- a/app/services/pricing/service.go
+++ b/app/services/pricing/service.go
@@ -43,7 +43,7 @@ type Service struct {
 	coinGeckoIds          map[uint64]map[string]string
 	tokensPriceInfo       map[uint64]map[string]pricing.TokenPriceInfo
 	minAmountsForApi      map[uint64]map[string]string
-	hbarFungibleAssetInfo asset.FungibleAssetInfo
+	hbarFungibleAssetInfo *asset.FungibleAssetInfo
 	hbarNativeAsset       *asset.NativeAsset
 	logger                *log.Entry
 }

--- a/bootstrap/clients.go
+++ b/bootstrap/clients.go
@@ -152,14 +152,14 @@ func InitEvmNftClients(networks map[uint64]*parser.Network, evmClients map[uint6
 		}
 
 		// Native Tokens
-		for fungibleTokenAddress, tokenInfo := range network.Tokens.Nft {
+		for nonFungibleTokenAddress, tokenInfo := range network.Tokens.Nft {
 
 			if networkId != constants.HederaNetworkId {
-				tokenInstance, err := werc721.NewWerc721(common.HexToAddress(fungibleTokenAddress), evmClients[networkId])
+				tokenInstance, err := werc721.NewWerc721(common.HexToAddress(nonFungibleTokenAddress), evmClients[networkId])
 				if err != nil {
-					log.Fatalf("Failed to initialize Native EvmFungibleToken Contract Instance at token address [%s]. Error [%s]", fungibleTokenAddress, err)
+					log.Fatalf("Failed to initialize Native EvmFungibleToken Contract Instance at token address [%s]. Error [%s]", nonFungibleTokenAddress, err)
 				}
-				tokenClients[networkId][fungibleTokenAddress] = tokenInstance
+				tokenClients[networkId][nonFungibleTokenAddress] = tokenInstance
 			}
 
 			// Wrapped tokens

--- a/bootstrap/server.go
+++ b/bootstrap/server.go
@@ -64,6 +64,9 @@ func InitializeServerPairs(server *server.Server, services *Services, repositori
 	// Hedera Native unlock Nft Handlers
 	registerHederaNativeUnlockNftHandlers(server, services, repositories, configuration)
 
+	// Assets Watcher
+	registerAssetsWatcher(server, services, configuration, clients)
+
 	// Prometheus Watcher
 	registerPrometheusWatcher(server, services, configuration, clients)
 
@@ -152,6 +155,15 @@ func registerEvmClients(server *server.Server, services *Services, repositories 
 	}
 }
 
+func registerAssetsWatcher(server *server.Server, services *Services, configuration config.Config, clients *Clients) {
+	server.AddWatcher(createAssetsWatcher(
+		clients.MirrorNode,
+		configuration,
+		clients.EvmFungibleTokenClients,
+		clients.EvmNFTClients,
+		services.Assets))
+}
+
 func registerPrometheusWatcher(server *server.Server, services *Services, configuration config.Config, clients *Clients) {
 	if configuration.Node.Monitoring.Enable {
 		dashboardPolling := configuration.Node.Monitoring.DashboardPolling * time.Minute
@@ -161,8 +173,8 @@ func registerPrometheusWatcher(server *server.Server, services *Services, config
 			clients.MirrorNode,
 			configuration,
 			services.Prometheus,
-			clients.EvmClients,
 			clients.EvmFungibleTokenClients,
+			clients.EvmNFTClients,
 			services.Assets))
 	} else {
 		log.Infoln("Monitoring is disabled. No metrics will be added.")

--- a/bootstrap/services.go
+++ b/bootstrap/services.go
@@ -34,6 +34,7 @@ import (
 	utilsSvc "github.com/limechain/hedera-eth-bridge-validator/app/services/utils"
 	"github.com/limechain/hedera-eth-bridge-validator/config"
 	"github.com/limechain/hedera-eth-bridge-validator/config/parser"
+	"github.com/limechain/hedera-eth-bridge-validator/constants"
 )
 
 type Services struct {
@@ -57,7 +58,15 @@ type Services struct {
 func PrepareServices(c config.Config, parsedBridge parser.Bridge, clients Clients, repositories Repositories) *Services {
 	evmSigners := make(map[uint64]service.Signer)
 	contractServices := make(map[uint64]service.Contracts)
-	assetsService := assets.NewService(parsedBridge.Networks, c.Bridge.Hedera.FeePercentages, clients.RouterClients, clients.MirrorNode, clients.EvmFungibleTokenClients, clients.EvmNFTClients)
+	assetsService := assets.NewService(
+		parsedBridge.Networks,
+		parsedBridge.Networks[constants.HederaNetworkId].BridgeAccount,
+		c.Bridge.Hedera.FeePercentages,
+		clients.RouterClients,
+		clients.MirrorNode,
+		clients.EvmFungibleTokenClients,
+		clients.EvmNFTClients,
+	)
 	c.Bridge.LoadStaticMinAmountsForWrappedFungibleTokens(parsedBridge, assetsService)
 
 	for _, client := range clients.EvmClients {

--- a/bootstrap/watchers.go
+++ b/bootstrap/watchers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/repository"
 	"github.com/limechain/hedera-eth-bridge-validator/app/domain/service"
+	aw "github.com/limechain/hedera-eth-bridge-validator/app/process/watcher/assets"
 	cmw "github.com/limechain/hedera-eth-bridge-validator/app/process/watcher/message"
 	pw "github.com/limechain/hedera-eth-bridge-validator/app/process/watcher/prometheus"
 	tw "github.com/limechain/hedera-eth-bridge-validator/app/process/watcher/transfer"
@@ -69,13 +70,30 @@ func createConsensusTopicWatcher(configuration *config.Config,
 		configuration.Node.Clients.Hedera.StartTimestamp)
 }
 
+func createAssetsWatcher(
+	mirrorNode client.MirrorNode,
+	configuration config.Config,
+	evmFungibleTokenClients map[uint64]map[string]client.EvmFungibleToken,
+	evmNonFungibleTokenClients map[uint64]map[string]client.EvmNft,
+	assetsService service.Assets,
+
+) *aw.Watcher {
+	log.Debugf("Added Prometheus Watcher for dashboard metrics")
+	return aw.NewWatcher(
+		mirrorNode,
+		configuration,
+		evmFungibleTokenClients,
+		evmNonFungibleTokenClients,
+		assetsService)
+}
+
 func createPrometheusWatcher(
 	dashboardPolling time.Duration,
 	mirrorNode client.MirrorNode,
 	configuration config.Config,
 	prometheusService service.Prometheus,
-	evmClients map[uint64]client.EVM,
-	evmTokenClients map[uint64]map[string]client.EvmFungibleToken,
+	evmFungibleTokenClients map[uint64]map[string]client.EvmFungibleToken,
+	evmNonFungibleTokenClients map[uint64]map[string]client.EvmNft,
 	assetsService service.Assets,
 
 ) *pw.Watcher {
@@ -85,7 +103,7 @@ func createPrometheusWatcher(
 		mirrorNode,
 		configuration,
 		prometheusService,
-		evmClients,
-		evmTokenClients,
+		evmFungibleTokenClients,
+		evmNonFungibleTokenClients,
 		assetsService)
 }

--- a/config/bridge_test.go
+++ b/config/bridge_test.go
@@ -36,6 +36,8 @@ var (
 	feePercentage     = int64(10000)
 	minFeeAmountInUsd = decimal.NewFromFloat(1)
 	topicId           = "0.0.1234567"
+	bridgeAccountId   = "0.0.476139"
+	reserveAmount     = big.NewInt(100)
 
 	////////////////////////
 	// Network 0 (Hedera) //
@@ -53,11 +55,12 @@ var (
 
 	networkHederaNFTNativeToken = "0.0.111122"
 
-	networkHederaFungibleNativeTokenFungibleAssetInfo = asset.FungibleAssetInfo{
-		networkHederaFungibleNativeToken,
-		networkHederaFungibleNativeToken,
-		constants.HederaDefaultDecimals,
-		true,
+	networkHederaFungibleNativeTokenFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          networkHederaFungibleNativeToken,
+		Symbol:        networkHederaFungibleNativeToken,
+		Decimals:      constants.HederaDefaultDecimals,
+		IsNative:      true,
+		ReserveAmount: reserveAmount,
 	}
 
 	//////////////////////
@@ -81,17 +84,17 @@ var (
 	// Wrapped Tokens //
 
 	networkEthereumFungibleWrappedTokenForNetworkHedera                  = "0x0000000000000000000000000000000000000555"
-	networkEthereumFungibleWrappedTokenForNetworkHederaFungibleAssetInfo = asset.FungibleAssetInfo{
-		networkEthereumFungibleWrappedTokenForNetworkHedera,
-		networkEthereumFungibleWrappedTokenForNetworkHedera,
-		constants.EvmDefaultDecimals,
-		false,
+	networkEthereumFungibleWrappedTokenForNetworkHederaFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          networkEthereumFungibleWrappedTokenForNetworkHedera,
+		Symbol:        networkEthereumFungibleWrappedTokenForNetworkHedera,
+		Decimals:      constants.EvmDefaultDecimals,
+		ReserveAmount: reserveAmount,
 	}
 
 	networks = map[uint64]*parser.Network{
 		constants.HederaNetworkId: {
 			Name:          "Hedera",
-			BridgeAccount: "0.0.476139",
+			BridgeAccount: bridgeAccountId,
 			PayerAccount:  "0.0.476139",
 			Members:       []string{"0.0.123", "0.0.321", "0.0.231"},
 			Tokens: parser.Tokens{

--- a/e2e/setup/config.go
+++ b/e2e/setup/config.go
@@ -92,7 +92,7 @@ func Load() *Setup {
 	}
 
 	routerClients, evmFungibleTokenClients, evmNftClients := routerAndEVMTokenClientsFromEVMUtils(setup.Clients.EVM)
-	setup.AssetMappings = assets.NewService(e2eConfig.Bridge.Networks, configuration.FeePercentages, routerClients, setup.Clients.MirrorNode, evmFungibleTokenClients, evmNftClients)
+	setup.AssetMappings = assets.NewService(e2eConfig.Bridge.Networks, e2eConfig.Hedera.BridgeAccount, configuration.FeePercentages, routerClients, setup.Clients.MirrorNode, evmFungibleTokenClients, evmNftClients)
 
 	return setup
 }

--- a/test/constants/bridge.go
+++ b/test/constants/bridge.go
@@ -19,8 +19,10 @@ package constants
 import (
 	"github.com/limechain/hedera-eth-bridge-validator/app/model/asset"
 	"github.com/limechain/hedera-eth-bridge-validator/config/parser"
-	"github.com/limechain/hedera-eth-bridge-validator/constants"
+	constants "github.com/limechain/hedera-eth-bridge-validator/constants"
 	"github.com/shopspring/decimal"
+	"math/big"
+	"strconv"
 )
 
 var (
@@ -29,11 +31,14 @@ var (
 	// Common //
 	////////////
 
-	EthereumNetworkId = uint64(1)
-	PolygonNetworkId  = uint64(137)
-	FeePercentage     = int64(10000)
-	MinFeeAmountInUsd = decimal.NewFromFloat(1)
-	TopicId           = "0.0.1234567"
+	FeePercentage                 = int64(10000)
+	MinFeeAmountInUsd             = decimal.NewFromFloat(1)
+	TopicId                       = "0.0.1234567"
+	BridgeAccountId               = "0.0.476139"
+	ReserveAmount                 = int64(100)
+	ReserveAmountStr              = strconv.FormatInt(ReserveAmount, 10)
+	ReserveAmountBigInt           = big.NewInt(ReserveAmount)
+	ReserveAmountWrappedNFTBigInt = big.NewInt(0)
 
 	////////////////////////
 	// Network 0 (Hedera) //
@@ -50,11 +55,12 @@ var (
 		Asset:             NetworkHederaFungibleNativeToken,
 		FeePercentage:     FeePercentage,
 	}
-	NetworkHederaFungibleNativeTokenFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkHederaFungibleNativeToken,
-		NetworkHederaFungibleNativeToken,
-		constants.HederaDefaultDecimals,
-		true,
+	NetworkHederaFungibleNativeTokenFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkHederaFungibleNativeToken,
+		Symbol:        NetworkHederaFungibleNativeToken,
+		Decimals:      constants.HederaDefaultDecimals,
+		IsNative:      true,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	// Non-Fungible
@@ -64,25 +70,29 @@ var (
 		ChainId: constants.HederaNetworkId,
 		Asset:   NetworkHederaNonFungibleNativeToken,
 	}
-	NetworkHederaNonFungibleNativeTokenNonFungibleAssetInfo = asset.NonFungibleAssetInfo{
-		NetworkHederaNonFungibleNativeToken,
-		NetworkHederaNonFungibleNativeToken,
-		true,
+	NetworkHederaNonFungibleNativeTokenNonFungibleAssetInfo = &asset.NonFungibleAssetInfo{
+		Name:          NetworkHederaNonFungibleNativeToken,
+		Symbol:        NetworkHederaNonFungibleNativeToken,
+		IsNative:      true,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	// Wrapped Tokens //
 
 	NetworkHederaFungibleWrappedTokenForNetworkPolygon                  = "0.0.000033"
-	NetworkHederaFungibleWrappedTokenForNetworkPolygonFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkHederaFungibleWrappedTokenForNetworkPolygon,
-		NetworkHederaFungibleWrappedTokenForNetworkPolygon,
-		constants.HederaDefaultDecimals,
-		false,
+	NetworkHederaFungibleWrappedTokenForNetworkPolygonFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkHederaFungibleWrappedTokenForNetworkPolygon,
+		Symbol:        NetworkHederaFungibleWrappedTokenForNetworkPolygon,
+		Decimals:      constants.HederaDefaultDecimals,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	//////////////////////
 	// Ethereum Network //
 	//////////////////////
+
+	EthereumNetworkId             = uint64(1)
+	EthereumRouterContractAddress = "0xb083879B1e10C8476802016CB12cd2F25a000000"
 
 	// Native Tokens //
 
@@ -96,38 +106,42 @@ var (
 		FeePercentage:     FeePercentage,
 	}
 
+	NetworkEthereumFungibleNativeTokenFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkEthereumFungibleNativeToken,
+		Symbol:        NetworkEthereumFungibleNativeToken,
+		Decimals:      constants.EvmDefaultDecimals,
+		IsNative:      true,
+		ReserveAmount: ReserveAmountBigInt,
+	}
+
 	// Non-Fungible
 
 	NetworkEthereumNFTWrappedTokenForNetworkHedera = "0x0000000000000000000000000000000000009999"
 
-	NetworkEthereumFungibleNativeTokenFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkEthereumFungibleNativeToken,
-		NetworkEthereumFungibleNativeToken,
-		constants.EvmDefaultDecimals,
-		true,
-	}
-
 	// Wrapped Tokens //
 
 	NetworkEthereumFungibleWrappedTokenForNetworkPolygon                  = "0x0000000000000000000000000000000000000133"
-	NetworkEthereumFungibleWrappedTokenForNetworkPolygonFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkEthereumFungibleWrappedTokenForNetworkPolygon,
-		NetworkEthereumFungibleWrappedTokenForNetworkPolygon,
-		constants.EvmDefaultDecimals,
-		false,
+	NetworkEthereumFungibleWrappedTokenForNetworkPolygonFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkEthereumFungibleWrappedTokenForNetworkPolygon,
+		Symbol:        NetworkEthereumFungibleWrappedTokenForNetworkPolygon,
+		Decimals:      constants.EvmDefaultDecimals,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	NetworkEthereumFungibleWrappedTokenForNetworkHedera                  = "0x0000000000000000000000000000000000000555"
-	NetworkEthereumFungibleWrappedTokenForNetworkHederaFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkEthereumFungibleWrappedTokenForNetworkHedera,
-		NetworkEthereumFungibleWrappedTokenForNetworkHedera,
-		constants.EvmDefaultDecimals,
-		false,
+	NetworkEthereumFungibleWrappedTokenForNetworkHederaFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkEthereumFungibleWrappedTokenForNetworkHedera,
+		Symbol:        NetworkEthereumFungibleWrappedTokenForNetworkHedera,
+		Decimals:      constants.EvmDefaultDecimals,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	/////////////////////
 	// Polygon Network //
 	/////////////////////
+
+	PolygonNetworkId             = uint64(137)
+	PolygonRouterContractAddress = "0xb083879B1e10C8476802016CB12cd2F25a000001"
 
 	// Native Tokens //
 
@@ -140,11 +154,12 @@ var (
 		Asset:             NetworkPolygonFungibleNativeToken,
 		FeePercentage:     FeePercentage,
 	}
-	NetworkPolygonFungibleNativeTokenFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkPolygonFungibleNativeToken,
-		NetworkPolygonFungibleNativeToken,
-		constants.EvmDefaultDecimals,
-		true,
+	NetworkPolygonFungibleNativeTokenFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkPolygonFungibleNativeToken,
+		Symbol:        NetworkPolygonFungibleNativeToken,
+		Decimals:      constants.EvmDefaultDecimals,
+		IsNative:      true,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	// Wrapped Tokens //
@@ -152,33 +167,34 @@ var (
 	// Fungible
 
 	NetworkPolygonFungibleWrappedTokenForNetworkHedera                  = "0x0000000000000000000000000000000000000001"
-	NetworkPolygonFungibleWrappedTokenForNetworkHederaFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkPolygonFungibleWrappedTokenForNetworkHedera,
-		NetworkPolygonFungibleWrappedTokenForNetworkHedera,
-		constants.EvmDefaultDecimals,
-		false,
+	NetworkPolygonFungibleWrappedTokenForNetworkHederaFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkPolygonFungibleWrappedTokenForNetworkHedera,
+		Symbol:        NetworkPolygonFungibleWrappedTokenForNetworkHedera,
+		Decimals:      constants.EvmDefaultDecimals,
+		ReserveAmount: ReserveAmountBigInt,
 	}
+
 	NetworkPolygonFungibleWrappedTokenForNetworkEthereum                  = "0x0000000000000000000000000000000000000123"
-	NetworkPolygonFungibleWrappedTokenForNetworkEthereumFungibleAssetInfo = asset.FungibleAssetInfo{
-		NetworkPolygonFungibleWrappedTokenForNetworkEthereum,
-		NetworkPolygonFungibleWrappedTokenForNetworkEthereum,
-		constants.EvmDefaultDecimals,
-		false,
+	NetworkPolygonFungibleWrappedTokenForNetworkEthereumFungibleAssetInfo = &asset.FungibleAssetInfo{
+		Name:          NetworkPolygonFungibleWrappedTokenForNetworkEthereum,
+		Symbol:        NetworkPolygonFungibleWrappedTokenForNetworkEthereum,
+		Decimals:      constants.EvmDefaultDecimals,
+		ReserveAmount: ReserveAmountBigInt,
 	}
 
 	// Non-Fungible
 
 	NetworkPolygonWrappedNonFungibleTokenForHedera                     = "0x0000000000000000000000000000000011111122"
-	NetworkPolygonWrappedNonFungibleTokenForHederaNonFungibleAssetInfo = asset.NonFungibleAssetInfo{
-		NetworkPolygonWrappedNonFungibleTokenForHedera,
-		NetworkPolygonWrappedNonFungibleTokenForHedera,
-		false,
+	NetworkPolygonWrappedNonFungibleTokenForHederaNonFungibleAssetInfo = &asset.NonFungibleAssetInfo{
+		Name:          NetworkPolygonWrappedNonFungibleTokenForHedera,
+		Symbol:        NetworkPolygonWrappedNonFungibleTokenForHedera,
+		ReserveAmount: ReserveAmountWrappedNFTBigInt,
 	}
 
 	Networks = map[uint64]*parser.Network{
 		constants.HederaNetworkId: {
 			Name:          "Hedera",
-			BridgeAccount: "0.0.476139",
+			BridgeAccount: BridgeAccountId,
 			PayerAccount:  "0.0.476139",
 			Members:       []string{"0.0.123", "0.0.321", "0.0.231"},
 			Tokens: parser.Tokens{
@@ -201,7 +217,8 @@ var (
 			},
 		},
 		EthereumNetworkId: {
-			Name: "Ethereum",
+			Name:                  "Ethereum",
+			RouterContractAddress: EthereumRouterContractAddress,
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					NetworkEthereumFungibleNativeToken: {
@@ -217,7 +234,8 @@ var (
 			},
 		},
 		PolygonNetworkId: {
-			Name: "Polygon",
+			Name:                  "Polygon",
+			RouterContractAddress: PolygonRouterContractAddress,
 			Tokens: parser.Tokens{
 				Fungible: map[string]parser.Token{
 					NetworkPolygonFungibleNativeToken: {
@@ -291,7 +309,7 @@ var (
 		},
 	}
 
-	FungibleAssetInfos = map[uint64]map[string]asset.FungibleAssetInfo{
+	FungibleAssetInfos = map[uint64]map[string]*asset.FungibleAssetInfo{
 		constants.HederaNetworkId: {
 			NetworkHederaFungibleNativeToken:                   NetworkHederaFungibleNativeTokenFungibleAssetInfo,
 			NetworkHederaFungibleWrappedTokenForNetworkPolygon: NetworkHederaFungibleWrappedTokenForNetworkPolygonFungibleAssetInfo,
@@ -315,7 +333,7 @@ var (
 		PolygonNetworkId:          {NetworkPolygonWrappedNonFungibleTokenForHedera},
 	}
 
-	NonFungibleAssetInfos = map[uint64]map[string]asset.NonFungibleAssetInfo{
+	NonFungibleAssetInfos = map[uint64]map[string]*asset.NonFungibleAssetInfo{
 		constants.HederaNetworkId: {
 			NetworkHederaNonFungibleNativeToken: NetworkHederaNonFungibleNativeTokenNonFungibleAssetInfo,
 		},

--- a/test/mocks/client/evm_nft_client_mock.go
+++ b/test/mocks/client/evm_nft_client_mock.go
@@ -18,7 +18,9 @@ package client
 
 import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
+	"math/big"
 )
 
 type MockEvmNonFungibleToken struct {
@@ -33,4 +35,9 @@ func (m *MockEvmNonFungibleToken) Name(opts *bind.CallOpts) (string, error) {
 func (m *MockEvmNonFungibleToken) Symbol(opts *bind.CallOpts) (string, error) {
 	args := m.Called(opts)
 	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *MockEvmNonFungibleToken) BalanceOf(opts *bind.CallOpts, owner common.Address) (*big.Int, error) {
+	args := m.Called(opts, owner)
+	return args.Get(0).(*big.Int), args.Error(1)
 }

--- a/test/mocks/service/assets_service_mock.go
+++ b/test/mocks/service/assets_service_mock.go
@@ -17,8 +17,10 @@
 package service
 
 import (
+	"github.com/limechain/hedera-eth-bridge-validator/app/domain/client"
 	assetModel "github.com/limechain/hedera-eth-bridge-validator/app/model/asset"
 	"github.com/stretchr/testify/mock"
+	"math/big"
 )
 
 type MockAssetsService struct {
@@ -96,19 +98,37 @@ func (mas *MockAssetsService) OppositeAsset(sourceChainId uint64, targetChainId 
 }
 
 // FungibleAssetInfo Gets FungibleAssetInfo
-func (mas *MockAssetsService) FungibleAssetInfo(networkId uint64, assetAddress string) (assetInfo assetModel.FungibleAssetInfo, exist bool) {
+func (mas *MockAssetsService) FungibleAssetInfo(networkId uint64, assetAddress string) (assetInfo *assetModel.FungibleAssetInfo, exist bool) {
 	args := mas.Called(networkId, assetAddress)
-	assetInfo = args.Get(0).(assetModel.FungibleAssetInfo)
+	assetInfo = args.Get(0).(*assetModel.FungibleAssetInfo)
 	exist = args.Get(1).(bool)
 
 	return assetInfo, exist
 }
 
 // NonFungibleAssetInfo Gets NonFungibleAssetInfo
-func (mas *MockAssetsService) NonFungibleAssetInfo(networkId uint64, assetAddress string) (assetInfo assetModel.NonFungibleAssetInfo, exist bool) {
+func (mas *MockAssetsService) NonFungibleAssetInfo(networkId uint64, assetAddress string) (assetInfo *assetModel.NonFungibleAssetInfo, exist bool) {
 	args := mas.Called(networkId, assetAddress)
-	assetInfo = args.Get(0).(assetModel.NonFungibleAssetInfo)
+	assetInfo = args.Get(0).(*assetModel.NonFungibleAssetInfo)
 	exist = args.Get(1).(bool)
 
 	return assetInfo, exist
+}
+
+// FetchHederaTokenReserveAmount Gets Hedera's Token Reserve Amount
+func (mas *MockAssetsService) FetchHederaTokenReserveAmount(assetId string, mirrorNode client.MirrorNode, isNative bool, hederaTokenBalances map[string]int) (reserveAmount *big.Int, err error) {
+	args := mas.Called(assetId, mirrorNode, isNative, hederaTokenBalances)
+	return args.Get(0).(*big.Int), args.Error(1)
+}
+
+// FetchEvmFungibleReserveAmount Gets EVM's Fungible Token Reserve Amount
+func (mas *MockAssetsService) FetchEvmFungibleReserveAmount(networkId uint64, assetAddress string, isNative bool, evmTokenClient client.EvmFungibleToken, routerContractAddress string) (inLowestDenomination *big.Int, err error) {
+	args := mas.Called(networkId, assetAddress, isNative, evmTokenClient, routerContractAddress)
+	return args.Get(0).(*big.Int), args.Error(1)
+}
+
+// FetchEvmNonFungibleReserveAmount Gets EVM's Non-Fungible Token Reserve Amount
+func (mas *MockAssetsService) FetchEvmNonFungibleReserveAmount(networkId uint64, assetAddress string, isNative bool, evmTokenClient client.EvmNft, routerContractAddress string) (inLowestDenomination *big.Int, err error) {
+	args := mas.Called(networkId, assetAddress, isNative, evmTokenClient, routerContractAddress)
+	return args.Get(0).(*big.Int), args.Error(1)
 }


### PR DESCRIPTION
Refactoring and Exposing 'ReserveAmounts' for assets on 'api/v1/assets' endpoint

Signed-off-by: Nikolay Nedkov <nikolay.nedkov@limechain.tech>

**Detailed description**:
Refactoring and Exposing 'ReserveAmounts' for assets on 'api/v1/assets' endpoint.

**Which issue(s) this PR fixes**:
Fixes #590

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

