### PR TITLE
Issues 748

### DIFF
--- a/app/model/pricing/pricing.go
+++ b/app/model/pricing/pricing.go
@@ -25,6 +25,7 @@ import (
 type TokenPriceInfo struct {
 	UsdPrice         decimal.Decimal
 	MinAmountWithFee *big.Int
+	DefaultMinAmount *big.Int
 }
 
 type NonFungibleFee struct {

--- a/app/process/watcher/evm/watcher_test.go
+++ b/app/process/watcher/evm/watcher_test.go
@@ -98,7 +98,7 @@ var (
 	hbarNativeAsset      = &asset.NativeAsset{ChainId: targetChainId, Asset: constants.Hbar}
 	fungibleAssetInfo    = &asset.FungibleAssetInfo{Decimals: 8}
 	evmFungibleAssetInfo = &asset.FungibleAssetInfo{Decimals: 18}
-	tokenPriceInfo       = pricing.TokenPriceInfo{decimal.NewFromFloat(20), big.NewInt(10000)}
+	tokenPriceInfo       = pricing.TokenPriceInfo{decimal.NewFromFloat(20), big.NewInt(10000), big.NewInt(10000)}
 )
 
 func Test_HandleLockLog_Removed_Fails(t *testing.T) {

--- a/app/process/watcher/transfer/watcher_test.go
+++ b/app/process/watcher/transfer/watcher_test.go
@@ -46,7 +46,7 @@ var (
 	nativeAssetNetwork0         = &asset.NativeAsset{ChainId: constants.HederaNetworkId, Asset: nativeTokenAddressNetwork0}
 	fungibleAssetInfoNetwork0   = &asset.FungibleAssetInfo{Decimals: 8}
 	fungibleAssetInfoNetwork3   = &asset.FungibleAssetInfo{Decimals: 18}
-	tokenPriceInfo              = pricing.TokenPriceInfo{decimal.NewFromFloat(20), big.NewInt(10000)}
+	tokenPriceInfo              = pricing.TokenPriceInfo{decimal.NewFromFloat(20), big.NewInt(10000), big.NewInt(10000)}
 
 	tx = transaction.Transaction{
 		TokenTransfers: []transaction.Transfer{


### PR DESCRIPTION
**Detailed description**:
- Add USD price cache fallback in situations, where fetching it fails.
- Add default minimum amount, to be used as a fallback for error in calculations ( previously caused  by USDprice == 0 )
- Add tests for the above functionalities

**Which issue(s) this PR fixes**:
Fixes #748 

**Special notes for your reviewer**:
- The `DefaultMinAmount` may be  redundant, since we already have cache for the USD price

**Checklist**
- [ ] Documentation added
- [x] Tests updated

