### PR TITLE
Add CI pipeline to check for outdated dependencies

### DIFF
--- a/.github/workflows/outdated-dependencies.yaml
+++ b/.github/workflows/outdated-dependencies.yaml
@@ -1,0 +1,17 @@
+name: Outdated Dependencies
+
+on:   
+  schedule:
+  - cron: "0 0 1 * *"
+
+jobs:
+  go-mod-outdated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        name: Setup GO Env
+        with:
+          go-version: '1.17'
+      - name: Run go-mod-outdated
+        run: go list -u -m -json all | docker run --rm -i psampaz/go-mod-outdated -update -direct -ci


### PR DESCRIPTION
This action will run once per month, and check for outdated project dependencies. This won't affect pull requests, and instead the results can be found in the `Actions` tab.

Results are displayed in a chart that shows the outdated version being used, and the new version. 
Indirect dependencies are not included (since we have no control over them).
