### PR TITLE
Second verification of fee sent with prev calculated hbar price

### DIFF
--- a/app/domain/service/pricing.go
+++ b/app/domain/service/pricing.go
@@ -29,6 +29,8 @@ type Pricing interface {
 	GetMinAmountsForAPI() map[uint64]map[string]string
 	// GetHederaNftFee returns the nft fee for Hedera NFTs based on token id
 	GetHederaNftFee(token string) (int64, bool)
+	// GetHederaNftPrevFee returns the previous nft fee for Hedera NFTs based on token id
+	GetHederaNftPrevFee(token string) (int64, bool)
 
 	NftFees() map[uint64]map[string]pricing.NonFungibleFee
 }

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -231,7 +231,7 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 			return
 		}
 
-		feeForValidators, ok := ctw.validateFeeSent(sourceAsset, tx, originator, nftAssetInfo, feeSent)
+		feeForValidators, ok := ctw.validateNFTFeeSent(sourceAsset, tx, originator, nftAssetInfo, feeSent)
 		if !ok {
 			return
 		}
@@ -291,7 +291,7 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 	q.Push(&queue.Message{Payload: transferMessage, Topic: topic})
 }
 
-func (ctw Watcher) validateFeeSent(sourceAsset string, tx transaction.Transaction, originator string, nftAssetInfo *asset.NonFungibleAssetInfo, feeSent int64) (int64, bool) {
+func (ctw Watcher) validateNFTFeeSent(sourceAsset string, tx transaction.Transaction, originator string, nftAssetInfo *asset.NonFungibleAssetInfo, feeSent int64) (int64, bool) {
 	fee, feeIsFound := ctw.pricingService.GetHederaNftFee(sourceAsset)
 	if !feeIsFound {
 		ctw.logger.Errorf("[%s] - Fee for [%s] not found.", tx.TransactionID, sourceAsset)
@@ -324,9 +324,9 @@ func (ctw Watcher) validateFeeSent(sourceAsset string, tx transaction.Transactio
 		ctw.logger.Errorf("[%s] - Invalid provided NFT Fee for [%s] in HBARs. It should be [%d], but was [%d].", tx.TransactionID, sourceAsset, fee, feeSent)
 
 		if prevFeeFound && fee != prevFee {
-			ctw.logger.Infof("[%s] - Try to validate NFT Fee for [%s] in HBARs with prevrous price.", tx.TransactionID, sourceAsset)
+			ctw.logger.Infof("[%s] - Trying to validate NFT Fee for [%s] in HBARs with previous price.", tx.TransactionID, sourceAsset)
 			if feeSent < totalHbarFeeExpectedWithPrev {
-				ctw.logger.Errorf("[%s] - Invalid provided NFT Fee for [%s] in HBARs with prevrous price. It should be [%d], but was [%d].", tx.TransactionID, sourceAsset, prevFee, feeSent)
+				ctw.logger.Errorf("[%s] - Invalid provided NFT Fee for [%s] in HBARs with previous price. It should be [%d], but was [%d].", tx.TransactionID, sourceAsset, prevFee, feeSent)
 				return 0, false
 			}
 		} else {

--- a/app/process/watcher/transfer/watcher.go
+++ b/app/process/watcher/transfer/watcher.go
@@ -231,38 +231,15 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 			return
 		}
 
-		fee, ok := ctw.pricingService.GetHederaNftFee(sourceAsset)
+		feeForValidators, ok := ctw.validateFeeSent(sourceAsset, tx, originator, nftAssetInfo, feeSent)
 		if !ok {
-			ctw.logger.Errorf("[%s] - Fee for [%s] not found.", tx.TransactionID, sourceAsset)
 			return
 		}
 
-		totalHbarFeeExpected := fee
-
-		feeForValidators := feeSent
-		if originator != nftAssetInfo.TreasuryAccountId { // Custom Fees are expected only for Non-Treasury Account ID
-			totalHbarFeeExpected += nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountInHbar
-			// Validate that the required Custom fees by Token ID are sent
-			if len(nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountsByTokenId) > 0 {
-				if !ctw.validateNftTokenCustomFees(nftAssetInfo, tx, sourceAsset) {
-					return
-				}
-			}
-			feeForValidators = feeForValidators - nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountInHbar
-		}
-
-		// Validate that the HBAR fee is sent (including the Custom Fee in HBAR)
-		if feeSent < totalHbarFeeExpected {
-			ctw.logger.Errorf("[%s] - Invalid provided NFT Fee for [%s] in HBARs. It should be [%d], but was [%d].", tx.TransactionID, sourceAsset, fee, feeSent)
-			return
-		}
-
-		transferMessage, err = ctw.createNonFungiblePayload(
-			tx.TransactionID, checkResult.EvmAddress, sourceAsset, *nativeAsset, checkResult.NftId.SerialNumber, targetChainId, targetChainAsset, feeForValidators)
+		transferMessage, err = ctw.createNonFungiblePayload(tx.TransactionID, checkResult.EvmAddress, sourceAsset, *nativeAsset, checkResult.NftId.SerialNumber, targetChainId, targetChainAsset, feeForValidators)
 
 	} else {
-		transferMessage, err = ctw.createFungiblePayload(
-			tx.TransactionID, checkResult.EvmAddress, sourceAsset, *nativeAsset, parsedTransfer.AmountOrSerialNum, targetChainId, targetChainAsset)
+		transferMessage, err = ctw.createFungiblePayload(tx.TransactionID, checkResult.EvmAddress, sourceAsset, *nativeAsset, parsedTransfer.AmountOrSerialNum, targetChainId, targetChainAsset)
 	}
 
 	if err != nil {
@@ -312,6 +289,52 @@ func (ctw Watcher) processTransaction(txID string, q qi.Queue) {
 	}
 
 	q.Push(&queue.Message{Payload: transferMessage, Topic: topic})
+}
+
+func (ctw Watcher) validateFeeSent(sourceAsset string, tx transaction.Transaction, originator string, nftAssetInfo *asset.NonFungibleAssetInfo, feeSent int64) (int64, bool) {
+	fee, feeIsFound := ctw.pricingService.GetHederaNftFee(sourceAsset)
+	if !feeIsFound {
+		ctw.logger.Errorf("[%s] - Fee for [%s] not found.", tx.TransactionID, sourceAsset)
+		return 0, false
+	}
+
+	prevFee, prevFeeFound := ctw.pricingService.GetHederaNftPrevFee(sourceAsset)
+
+	totalHbarFeeExpected := fee
+	totalHbarFeeExpectedWithPrev := prevFee
+
+	feeForValidators := feeSent
+	if originator != nftAssetInfo.TreasuryAccountId {
+		// Custom Fees are expected only for Non-Treasury Account ID
+		totalHbarFeeExpected += nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountInHbar
+		totalHbarFeeExpectedWithPrev += nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountInHbar
+
+		// Validate that the required Custom fees by Token ID are sent
+		if len(nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountsByTokenId) > 0 {
+			if !ctw.validateNftTokenCustomFees(nftAssetInfo, tx, sourceAsset) {
+				return 0, false
+			}
+		}
+
+		feeForValidators = feeForValidators - nftAssetInfo.CustomFeeTotalAmounts.FallbackFeeAmountInHbar
+	}
+
+	// Validate that the HBAR fee is sent (including the Custom Fee in HBAR)
+	if feeSent < totalHbarFeeExpected {
+		ctw.logger.Errorf("[%s] - Invalid provided NFT Fee for [%s] in HBARs. It should be [%d], but was [%d].", tx.TransactionID, sourceAsset, fee, feeSent)
+
+		if prevFeeFound && fee != prevFee {
+			ctw.logger.Infof("[%s] - Try to validate NFT Fee for [%s] in HBARs with prevrous price.", tx.TransactionID, sourceAsset)
+			if feeSent < totalHbarFeeExpectedWithPrev {
+				ctw.logger.Errorf("[%s] - Invalid provided NFT Fee for [%s] in HBARs with prevrous price. It should be [%d], but was [%d].", tx.TransactionID, sourceAsset, prevFee, feeSent)
+				return 0, false
+			}
+		} else {
+			return 0, false
+		}
+	}
+
+	return feeForValidators, true
 }
 
 func (ctw Watcher) validateNftTokenCustomFees(nftAssetInfo *asset.NonFungibleAssetInfo, tx transaction.Transaction, sourceAsset string) bool {
@@ -388,7 +411,7 @@ func (ctw Watcher) createNonFungiblePayload(
 	if err != nil {
 		return nil, err
 	}
-	
+
 	decodedMetadata, e := base64.StdEncoding.DecodeString(nftData.Metadata)
 	if e != nil {
 		return nil, fmt.Errorf("[%s] - Failed to decode metadata [%s]. Error [%s]", transactionID, nftData.Metadata, e)

--- a/app/process/watcher/transfer/watcher_test.go
+++ b/app/process/watcher/transfer/watcher_test.go
@@ -200,12 +200,12 @@ func Test_ProcessTransaction_GetIncomingTransfer_Fails(t *testing.T) {
 	mocks.MTransferService.AssertNotCalled(t, "SanityCheckTransfer", mock.Anything)
 }
 
-func Test_validateFeeSent_ShouldNotValidateFee(t *testing.T) {
+func Test_validateNFTFeeSent_ShouldNotValidateFee(t *testing.T) {
 	w := initializeWatcher()
 
 	mocks.MPricingService.On("GetHederaNftFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(0), false)
 
-	feeForValidators, ok := w.validateFeeSent(
+	feeForValidators, ok := w.validateNFTFeeSent(
 		testConstants.NetworkHederaNonFungibleNativeToken,
 		tx,
 		"",
@@ -216,13 +216,13 @@ func Test_validateFeeSent_ShouldNotValidateFee(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func Test_validateFeeSent_ShouldValidateFee(t *testing.T) {
+func Test_validateNFTFeeSent_ShouldValidateFee(t *testing.T) {
 	w := initializeWatcher()
 
 	mocks.MPricingService.On("GetHederaNftFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(10), true)
 	mocks.MPricingService.On("GetHederaNftPrevFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(20), true)
 
-	feeForValidators, ok := w.validateFeeSent(
+	feeForValidators, ok := w.validateNFTFeeSent(
 		testConstants.NetworkHederaNonFungibleNativeToken,
 		tx,
 		"",
@@ -233,13 +233,13 @@ func Test_validateFeeSent_ShouldValidateFee(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func Test_validateFeeSent_ShouldValidatePrevFee(t *testing.T) {
+func Test_validateNFTFeeSent_ShouldValidatePrevFee(t *testing.T) {
 	w := initializeWatcher()
 
 	mocks.MPricingService.On("GetHederaNftFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(10), true)
 	mocks.MPricingService.On("GetHederaNftPrevFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(20), true)
 
-	feeForValidators, ok := w.validateFeeSent(
+	feeForValidators, ok := w.validateNFTFeeSent(
 		testConstants.NetworkHederaNonFungibleNativeToken,
 		tx,
 		"",
@@ -250,13 +250,13 @@ func Test_validateFeeSent_ShouldValidatePrevFee(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func Test_validateFeeSent_ShouldNotValidateAnyFee(t *testing.T) {
+func Test_validateNFTFeeSent_ShouldNotValidateAnyFee(t *testing.T) {
 	w := initializeWatcher()
 
 	mocks.MPricingService.On("GetHederaNftFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(0), false)
 	mocks.MPricingService.On("GetHederaNftPrevFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(0), false)
 
-	feeForValidators, ok := w.validateFeeSent(
+	feeForValidators, ok := w.validateNFTFeeSent(
 		testConstants.NetworkHederaNonFungibleNativeToken,
 		tx,
 		"",
@@ -267,13 +267,13 @@ func Test_validateFeeSent_ShouldNotValidateAnyFee(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func Test_validateFeeSent_ShouldNotValidateFeeWithOriginator(t *testing.T) {
+func Test_validateNFTFeeSent_ShouldNotValidateFeeWithOriginator(t *testing.T) {
 	w := initializeWatcher()
 
 	mocks.MPricingService.On("GetHederaNftFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(10), true)
 	mocks.MPricingService.On("GetHederaNftPrevFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(20), true)
 
-	feeForValidators, ok := w.validateFeeSent(
+	feeForValidators, ok := w.validateNFTFeeSent(
 		testConstants.NetworkHederaNonFungibleNativeToken,
 		tx,
 		"different originator",
@@ -284,13 +284,13 @@ func Test_validateFeeSent_ShouldNotValidateFeeWithOriginator(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func Test_validateFeeSent_ShouldValidateLargerFee(t *testing.T) {
+func Test_validateNFTFeeSent_ShouldValidateLargerFee(t *testing.T) {
 	w := initializeWatcher()
 
 	mocks.MPricingService.On("GetHederaNftFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(10), true)
 	mocks.MPricingService.On("GetHederaNftPrevFee", testConstants.NetworkHederaNonFungibleNativeToken).Return(int64(20), true)
 
-	feeForValidators, ok := w.validateFeeSent(
+	feeForValidators, ok := w.validateNFTFeeSent(
 		testConstants.NetworkHederaNonFungibleNativeToken,
 		tx,
 		"",

--- a/test/constants/bridge.go
+++ b/test/constants/bridge.go
@@ -17,9 +17,10 @@
 package constants
 
 import (
-	"github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node/model/token"
 	"math/big"
 	"strconv"
+
+	"github.com/limechain/hedera-eth-bridge-validator/app/clients/hedera/mirror-node/model/token"
 
 	"github.com/limechain/hedera-eth-bridge-validator/app/model/pricing"
 
@@ -388,6 +389,10 @@ var (
 
 	HederaNftFees = map[string]int64{
 		NetworkHederaNonFungibleNativeToken: 1000,
+	}
+
+	HederaNftDynamicFees = map[string]decimal.Decimal{
+		NetworkHederaNonFungibleNativeToken: decimal.NewFromInt(2000),
 	}
 
 	PaymentTokens = map[uint64]string{

--- a/test/mocks/repository/transfer_repository_mock.go
+++ b/test/mocks/repository/transfer_repository_mock.go
@@ -73,11 +73,9 @@ func (m *MockTransferRepository) UpdateStatusCompleted(txId string) error {
 }
 
 func (m *MockTransferRepository) Paged(req *transfer.PagedRequest) ([]*entity.Transfer, error) {
-	//TODO implement me
 	panic("implement me")
 }
 
 func (m *MockTransferRepository) Count() (int64, error) {
-	//TODO implement me
 	panic("implement me")
 }

--- a/test/mocks/service/pricing_service_mock.go
+++ b/test/mocks/service/pricing_service_mock.go
@@ -51,7 +51,16 @@ func (mas *MockPricingService) GetMinAmountsForAPI() map[uint64]map[string]strin
 
 // GetHederaNftFee returns the nft fee for Hedera NFTs based on token id
 func (mas *MockPricingService) GetHederaNftFee(token string) (int64, bool) {
-	args := mas.Called()
+	args := mas.Called(token)
+	fee := args.Get(0).(int64)
+	exist := args.Get(1).(bool)
+
+	return fee, exist
+}
+
+// GetHederaNftPrevFee returns the previous nft fee for Hedera NFTs based on token id
+func (mas *MockPricingService) GetHederaNftPrevFee(token string) (int64, bool) {
+	args := mas.Called(token)
 	fee := args.Get(0).(int64)
 	exist := args.Get(1).(bool)
 

--- a/test/mocks/service/transfer_service_mock.go
+++ b/test/mocks/service/transfer_service_mock.go
@@ -107,6 +107,5 @@ func (mts *MockTransferService) TransferData(txId string) (interface{}, error) {
 }
 
 func (mts *MockTransferService) Paged(filter *transfer.PagedRequest) (*transfer.Paged, error) {
-	//TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
Add function in transfer watcher to handle fee sent verification 
Add functionality in pricing service to store prev calculated nft fee 

Signed-off-by: Trayan Manolov <trayan.manolov@limechain.tech>

**Detailed description**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated

