### PR TITLE
Change block timestamp fetching to use header only

### DIFF
--- a/app/clients/evm/client.go
+++ b/app/clients/evm/client.go
@@ -101,7 +101,7 @@ func (ec *Client) ValidateContractDeployedAt(contractAddress string) (*common.Ad
 
 // GetBlockTimestamp retrieves the timestamp of the given block
 func (ec *Client) GetBlockTimestamp(blockNumber *big.Int) uint64 {
-	block, err := ec.BlockByNumber(context.Background(), blockNumber)
+	block, err := ec.HeaderByNumber(context.Background(), blockNumber)
 
 	if err != nil {
 		ec.logger.Errorf("Failed to get block [%s]. Error: [%s]. Retrying...", blockNumber, err)
@@ -109,7 +109,7 @@ func (ec *Client) GetBlockTimestamp(blockNumber *big.Int) uint64 {
 		return ec.GetBlockTimestamp(blockNumber)
 	}
 
-	return block.Time()
+	return block.Time
 }
 
 // WaitForTransactionCallback waits for transaction receipt and depending on receipt status calls one of the provided functions

--- a/app/clients/evm/client_test.go
+++ b/app/clients/evm/client_test.go
@@ -111,9 +111,7 @@ func Test_GetBlockTimestamp(t *testing.T) {
 	setup()
 	now := uint64(time.Now().Unix())
 	blockNumber := big.NewInt(1)
-	mocks.MEVMCoreClient.On("BlockByNumber", context.Background(), blockNumber).Return(types.NewBlockWithHeader(
-		&types.Header{Time: now},
-	), nil)
+	mocks.MEVMCoreClient.On("HeaderByNumber", context.Background(), blockNumber).Return(&types.Header{Time: now}, nil)
 	ts := c.GetBlockTimestamp(blockNumber)
 	assert.Equal(t, now, ts)
 }
@@ -122,10 +120,8 @@ func Test_GetBlockTimestamp_Fails(t *testing.T) {
 	setup()
 	blockNumber := big.NewInt(1)
 	now := uint64(time.Now().Unix())
-	mocks.MEVMCoreClient.On("BlockByNumber", context.Background(), blockNumber).Return(nil, errors.New("some-error")).Once()
-	mocks.MEVMCoreClient.On("BlockByNumber", context.Background(), blockNumber).Return(types.NewBlockWithHeader(
-		&types.Header{Time: now},
-	), nil)
+	mocks.MEVMCoreClient.On("HeaderByNumber", context.Background(), blockNumber).Return(nil, errors.New("some-error")).Once()
+	mocks.MEVMCoreClient.On("HeaderByNumber", context.Background(), blockNumber).Return(&types.Header{Time: now}, nil)
 	res := c.GetBlockTimestamp(blockNumber)
 	assert.Equal(t, now, res)
 }

--- a/test/mocks/client/evm_core_client_mock.go
+++ b/test/mocks/client/evm_core_client_mock.go
@@ -155,8 +155,19 @@ func (m *MockEVMCore) CallContract(ctx context.Context, call ethereum.CallMsg, b
 	return args[0].([]byte), args[1].(error)
 }
 func (m *MockEVMCore) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
-	panic("implement me")
+	args := m.Called(ctx, number)
+	if args[0] == nil && args[1] == nil {
+		return nil, nil
+	}
+	if args[0] == nil {
+		return nil, args[1].(error)
+	}
+	if args[1] == nil {
+		return args[0].(*types.Header), nil
+	}
+	return args[0].(*types.Header), args[1].(error)
 }
+
 func (m *MockEVMCore) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
 	args := m.Called(ctx, account)
 	if args[0] == nil && args[1] == nil {


### PR DESCRIPTION
Signed-off-by: Antonio Mindov <antonio.mindov@limechain.tech>

**Detailed description**:
This should fix the transaction fetching from Arbitrum and Optimism

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

