### PR TITLE
Fixed a memory leak in the Retry functionality for EVM clients

### DIFF
--- a/app/domain/service/errors.go
+++ b/app/domain/service/errors.go
@@ -16,8 +16,12 @@
 
 package service
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var ErrNotFound = errors.New("not found")
 var ErrBadRequestTransferTargetNetworkNoSignaturesRequired = errors.New("transfer target network does not require signatures")
 var ErrWrongQuery = errors.New("wrong query parameter")
+var ErrTooManyRetires = fmt.Errorf("too many retries")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,26 +26,15 @@ import (
 	"github.com/limechain/hedera-eth-bridge-validator/app/process/recovery"
 	"github.com/limechain/hedera-eth-bridge-validator/bootstrap"
 	"github.com/limechain/hedera-eth-bridge-validator/config"
-	"github.com/pkg/profile"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-
 	_ "net/http/pprof"
 )
 
 func main() {
 	// Config
-	defer profile.Start(profile.MemProfile).Stop()
-
 	configuration, parsedBridge, err := config.LoadConfig()
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
-	}
-
-	if !configuration.Node.Validator {
-		go func() {
-			http.ListenAndServe(":8080", nil)
-		}()
 	}
 
 	config.InitLogger(configuration.Node.LogLevel, configuration.Node.LogFormat)


### PR DESCRIPTION
**Detailed description**:
The retry loop was leaking go routine from the flow which was not finished(either the timeout or the `executionFunction` because when one finished the other couldn't send a message on it's channel.

The solution is to just use a context with a timeout and leave the handling to the user which works perfectly in our case as everywhere we are using this we are already using a context.

**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated

