### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/app/helper/big-numbers/helper.go
+++ b/app/helper/big-numbers/helper.go
@@ -30,11 +30,3 @@ func ToBigInt(value string) (*big.Int, error) {
 
 	return amount, nil
 }
-
-// Max returns the larger of x or y.
-func Max(x, y uint64) uint64 {
-	if x < y {
-		return y
-	}
-	return x
-}

--- a/app/process/watcher/evm/watcher.go
+++ b/app/process/watcher/evm/watcher.go
@@ -108,7 +108,7 @@ func NewWatcher(
 	if err != nil {
 		log.Fatalf("Could not retrieve latest block. Error: [%s].", err)
 	}
-	targetBlock := bigNumbersHelper.Max(0, currentBlock-evmClient.BlockConfirmations())
+	targetBlock := max(0, currentBlock-evmClient.BlockConfirmations())
 
 	abi, err := abi.JSON(strings.NewReader(router.RouterABI))
 	if err != nil {


### PR DESCRIPTION
**Detailed description**:

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

