### PR TITLE
Implement GasPriceClient

### DIFF
--- a/app/clients/evm/gas-price/client.go
+++ b/app/clients/evm/gas-price/client.go
@@ -26,16 +26,22 @@ type gasPricer interface {
 	SuggestGasPrice(ctx context.Context) (*big.Int, error)
 }
 
-type Client struct {
+type GasClienter interface {
+	GetGasPrice(ctx context.Context) (*big.Int, error)
+}
+
+var _ GasClienter = (*GasClient)(nil)
+
+type GasClient struct {
 	evmClient gasPricer
 }
 
-func NewClient(evmClient gasPricer) *Client {
-	return &Client{evmClient: evmClient}
+func NewClient(evmClient gasPricer) GasClienter {
+	return &GasClient{evmClient: evmClient}
 }
 
 // GetGasPrice returns the suggested gas price for the EVM chain
-func (c *Client) GetGasPrice(ctx context.Context) (*big.Int, error) {
+func (c *GasClient) GetGasPrice(ctx context.Context) (*big.Int, error) {
 	gasPrice, err := c.evmClient.SuggestGasPrice(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gas price: %w", err)

--- a/app/clients/evm/gas-price/client.go
+++ b/app/clients/evm/gas-price/client.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gas_price
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+)
+
+type gasPricer interface {
+	SuggestGasPrice(ctx context.Context) (*big.Int, error)
+}
+
+type Client struct {
+	evmClient gasPricer
+}
+
+func NewClient(evmClient gasPricer) *Client {
+	return &Client{evmClient: evmClient}
+}
+
+// GetGasPrice returns the suggested gas price for the EVM chain
+func (c *Client) GetGasPrice(ctx context.Context) (*big.Int, error) {
+	gasPrice, err := c.evmClient.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gas price: %w", err)
+	}
+
+	return gasPrice, nil
+}

--- a/app/clients/evm/gas-price/client_test.go
+++ b/app/clients/evm/gas-price/client_test.go
@@ -27,13 +27,13 @@ import (
 )
 
 var (
-	gasPriceClient *Client
+	gasPriceClient *GasClient
 	mockEVM        *mocksClient.MockEVM
 )
 
 func setup() {
 	mockEVM = &mocksClient.MockEVM{}
-	gasPriceClient = NewClient(mockEVM)
+	gasPriceClient = NewClient(mockEVM).(*GasClient)
 }
 
 func TestGetGasPrice_Success(t *testing.T) {

--- a/app/clients/evm/gas-price/client_test.go
+++ b/app/clients/evm/gas-price/client_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gas_price
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	mocksClient "github.com/limechain/hedera-eth-bridge-validator/test/mocks/client"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	gasPriceClient *Client
+	mockEVM        *mocksClient.MockEVM
+)
+
+func setup() {
+	mockEVM = &mocksClient.MockEVM{}
+	gasPriceClient = NewClient(mockEVM)
+}
+
+func TestGetGasPrice_Success(t *testing.T) {
+	setup()
+	expected := big.NewInt(20_000_000_000)
+	mockEVM.On("SuggestGasPrice", context.Background()).Return(expected, nil)
+
+	result, err := gasPriceClient.GetGasPrice(context.Background())
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+	mockEVM.AssertExpectations(t)
+}
+
+func TestGetGasPrice_SuggestGasPriceFails(t *testing.T) {
+	setup()
+	mockEVM.On("SuggestGasPrice", context.Background()).Return((*big.Int)(nil), errors.New("rpc error"))
+
+	result, err := gasPriceClient.GetGasPrice(context.Background())
+
+	assert.Nil(t, result)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "rpc error")
+	mockEVM.AssertExpectations(t)
+}

--- a/app/domain/client/gas_price.go
+++ b/app/domain/client/gas_price.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"math/big"
+)
+
+type GasPrice interface {
+	// GetGasPrice returns the suggested gas price for the EVM chain
+	GetGasPrice(ctx context.Context) (*big.Int, error)
+}

--- a/app/domain/client/gas_price.go
+++ b/app/domain/client/gas_price.go
@@ -21,7 +21,7 @@ import (
 	"math/big"
 )
 
-type GasPrice interface {
+type GasClienter interface {
 	// GetGasPrice returns the suggested gas price for the EVM chain
 	GetGasPrice(ctx context.Context) (*big.Int, error)
 }

--- a/test/mocks/client/gas_price_client_mock.go
+++ b/test/mocks/client/gas_price_client_mock.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 LimeChain Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MockGasPriceClient struct {
+	mock.Mock
+}
+
+func (m *MockGasPriceClient) GetGasPrice(ctx context.Context) (*big.Int, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*big.Int), args.Error(1)
+}


### PR DESCRIPTION
Added a GasPrice client: a client.GasPrice interface and a gas_price.Client that delegates to the existing EVM stack via SuggestGasPrice, returning the suggested price in wei. Includes unit tests and a MockGasPriceClient.